### PR TITLE
refactor(api): simplify analyzePGN overloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ Public barrels re-export **user-facing** names from the **owning** module. Inter
 `analyzePGN` picks one of two internal paths:
 
 1. **Single-threaded** — `workers: false`. Main thread: I/O (`readLines`) → PGN parse (`GameAssembler`) → replay (`GameReplayer`, mode from per-config `replayMode`) → analyze (trackers).
-2. **Multithreaded (worker-chunk)** — default. Main thread: I/O + chunking (`readPgnChunks`) → workers PGN-parse once per chunk (once per chunk for all `runs` in a multi-run task). Workers replay and accumulate tracker state; per-batch worker→main posts counts/errors only, tracker payloads flush at pool drain. `maxGames` is enforced on workers. **JavaScript `filter` predicates require `workers: false`** (validated in `normalizeAnalyzeOptions`).
+2. **Multithreaded (worker-chunk)** — default. Main thread: I/O + chunking (`readPgnChunks`) → workers PGN-parse once per chunk (once per chunk for all `runs` in a multi-run task). Workers replay and accumulate tracker state; per-batch worker→main posts counts/errors only, tracker payloads flush at pool drain. `maxGames` is enforced on workers. **JavaScript `filter` predicates imply single-threaded analysis** (`workers` omitted or `false`); an explicit worker pool with a filter is rejected in `normalizeAnalyzeOptions`.
 
 **Replay mode:** Default from `resolveReplayMode(hasMoveTrackers)`; override via `AnalyzeOptions.replay` (`resolveEffectiveReplayMode`). Move trackers require `'actions'`. Per-config `replayMode` is stored at normalization and passed to workers via `WorkerInitData`. Count-only runs skip board replay by default (`SKIP_REPLAY_WITHOUT_MOVE_TRACKERS = true` in [`src/replay/replay-mode.ts`](src/replay/replay-mode.ts)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Filters no longer require `workers: false`:** a JavaScript `filter` implies single-threaded analysis when `workers` is omitted (or set to `false`). Combining a filter with an explicit worker pool (`workers: n` / `workers: { … }`) is still a type and runtime error. `analyzePGN` overloads were simplified to a single-run generic plus a catch-all `AnalyzeOptions` signature.
+
 ## [4.0.0-beta.0] - 2026-08-04
 
 First beta release. Only minor planned API changes, if at all.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ A JavaScript library for batch-analyzing chess PGN files — parse games, replay
 
 [![npm version](https://badge.fury.io/js/chessalyzer.svg)](https://badge.fury.io/js/chessalyzer)
 
+## Features
+
+- Zero-dependency chess analysis and PGN parsing toolkit
+- Batch process PGN files and track statistics of your games
+- Filter games (e.g. only analyze games where WhiteElo > 1800)
+- Fully modular, track only the statistics you need
+- Generate heatmaps out of the generated data
+- Standalone fast PGN parser with sync and async streaming mode
+- Handles big files easily
+
 ## Documentation
 
 Guides for installation, basic usage, the analysis pipeline, built-in and custom trackers, heatmaps, filtering, multithreading, error handling, and more can be found in the **[Documentation](https://yschroe.github.io/chessalyzer/)**.

--- a/bun.lock
+++ b/bun.lock
@@ -7,14 +7,14 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "@types/node": "^26.1.2",
-        "bumpp": "^12.1.1",
+        "bumpp": "^12.2.0",
         "bun-plugin-dts": "^0.4.0",
-        "knip": "^6.31.0",
+        "knip": "^6.32.0",
         "oxfmt": "^0.62.0",
         "oxlint": "^1.77.0",
         "oxlint-tsgolint": "^7.0.2001",
         "tinybench": "^6.1.2",
-        "tsx": "^4.23.5",
+        "tsx": "^4.23.9",
         "typescript": "6.0.3",
       },
     },
@@ -534,7 +534,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bumpp": ["bumpp@12.1.1", "", { "dependencies": { "args-tokenizer": "^0.3.0", "cac": "^7.0.0", "jsonc-parser": "^3.3.1", "package-manager-detector": "^1.8.0", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "unconfig": "^7.5.0", "verkit": "^0.3.0", "yaml": "^2.9.0" }, "bin": { "bumpp": "bin/bumpp.mjs" } }, "sha512-6zniIxMtt+yeEwmyL4s+gB54A1J8HVQPOIeABaFB2ScmG993Q+3+5MYAbJYu/kmZ1ZXS+KzwVb/ff5V4vBXiHA=="],
+    "bumpp": ["bumpp@12.2.0", "", { "dependencies": { "args-tokenizer": "^0.3.0", "cac": "^7.0.0", "jsonc-parser": "^3.3.1", "package-manager-detector": "^1.8.0", "tinyexec": "^1.3.0", "tinyglobby": "^0.2.17", "unconfig": "^7.5.0", "verkit": "^0.3.2", "yaml": "^2.9.0" }, "bin": { "bumpp": "bin/bumpp.mjs" } }, "sha512-pQuDUxqHpxxjfie/KABu0fppefIthnC/ZEIzcoSDy3RVxhascgsl+NI21+wQec6tTLr+wNQTLcjSeTSGr80qAw=="],
 
     "bun-plugin-dts": ["bun-plugin-dts@0.4.0", "", { "dependencies": { "common-path-prefix": "^3.0.0", "dts-bundle-generator": "^9.5.1", "get-tsconfig": "^4.13.6" } }, "sha512-g/pHy9SuhnUw+E+bHnJvADOnnZlEIci3nvZY8EuQEMwkpC4V4Kmoa2nG9nfda4jmjj+0POlCRCjdqXrL9gjYtA=="],
 
@@ -726,7 +726,7 @@
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
-    "knip": ["knip@6.31.0", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "oxc-parser": "^0.142.0", "oxc-resolver": "11.24.2", "picomatch": "^4.0.5", "smol-toml": "^1.7.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.4", "yaml": "^2.9.0", "zod": "^4.4.3" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-NbeIEmUS2VUMjAkbiSNOKPJeV9wpCsr0660sUyKyMQbk4Iom0++nTLInVp4MJ+LfR4kORnw67bDi5tvO7YLnzA=="],
+    "knip": ["knip@6.32.0", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.1", "jiti": "^2.7.0", "oxc-parser": "^0.142.0", "oxc-resolver": "11.24.2", "picomatch": "^4.0.5", "smol-toml": "^1.7.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.4", "yaml": "^2.9.0", "zod": "^4.4.3" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-KDX9OmmOFmlvmxTkrx6Z0GHISMut+pXMSKR8eg84bovaxJKx2NdQD4JYCXveSbvieRe107W6vCD2xCpmz0qBYA=="],
 
     "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 
@@ -1020,7 +1020,7 @@
 
     "tinybench": ["tinybench@6.1.2", "", {}, "sha512-REdMxUreK3VSUeWcLd5+ijUGNKFyHT8s1trKmYEE/tlYE6ggdOkFOlKba/vI/l1fIqh/NTEEr1Cyw4AwttOicA=="],
 
-    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
@@ -1032,7 +1032,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsx": ["tsx@4.23.5", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg=="],
+    "tsx": ["tsx@4.23.9", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-6q8uTORRGauQVjqMQnKUucLFoeXZAfw6zKvG35GLbdKWbLdeOtZ3H4mhyA5mxuUd2o2cRTskhj59nLLQseUvUw=="],
 
     "turbo-stream": ["turbo-stream@3.2.0", "", {}, "sha512-EK+bZ9UVrVh7JLslVFOV0GEMsociOqVOvEMTAd4ixMyffN5YNIEdLZWXUx5PJqDbTxSIBWw04HS9gCY4frYQDQ=="],
 
@@ -1070,7 +1070,7 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
-    "verkit": ["verkit@0.3.1", "", {}, "sha512-w2Eo8LSIIoW7qxNBzT7/17k+bh8plXo7G3dHjEIDqPlnluhzaxr9JX8F28VSYEtDvc1/a3WBDih6xNUZseebXg=="],
+    "verkit": ["verkit@0.3.2", "", {}, "sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -1137,6 +1137,10 @@
     "@vitejs/plugin-rsc/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "fumadocs-mdx/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "knip/get-tsconfig": ["get-tsconfig@4.14.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -21,14 +21,14 @@
     "docs": {
       "name": "chessalyzer-docs",
       "dependencies": {
-        "fumadocs-core": "16.14.0",
-        "fumadocs-mdx": "15.2.1",
-        "fumadocs-ui": "npm:@fumadocs/base-ui@16.14.0",
-        "lucide-react": "^1.28.0",
+        "fumadocs-core": "16.14.1",
+        "fumadocs-mdx": "15.2.2",
+        "fumadocs-ui": "npm:@fumadocs/base-ui@16.14.1",
+        "lucide-react": "^1.29.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-server-dom-webpack": "^19.2.8",
-        "takumi-js": "^2.5.4",
+        "takumi-js": "^2.5.10",
         "use-sync-external-store": "^1.6.0",
         "waku": "1.0.0-beta.8",
       },
@@ -40,7 +40,7 @@
         "@types/react-dom": "^19.2.4",
         "tailwindcss": "^4.3.3",
         "typescript": "^6.0.3",
-        "vite": "^8.2.0",
+        "vite": "^8.2.1",
       },
     },
   },
@@ -50,9 +50,9 @@
   "packages": {
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@base-ui/react": ["@base-ui/react@1.6.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.3.1", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw=="],
+    "@base-ui/react": ["@base-ui/react@1.7.0", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@base-ui/utils": "0.3.2", "@floating-ui/react-dom": "^2.1.9", "@floating-ui/utils": "^0.2.12", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@date-fns/tz": "^1.2.0", "@types/react": "^17 || ^18 || ^19", "date-fns": "^4.0.0", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@date-fns/tz", "@types/react", "date-fns"] }, "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug=="],
 
-    "@base-ui/utils": ["@base-ui/utils@0.3.1", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.11", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg=="],
+    "@base-ui/utils": ["@base-ui/utils@0.3.2", "", { "dependencies": { "@babel/runtime": "^7.29.2", "@floating-ui/utils": "^0.2.12", "reselect": "^5.2.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 
@@ -392,27 +392,27 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
 
-    "@takumi-rs/core": ["@takumi-rs/core@2.5.4", "", { "dependencies": { "@takumi-rs/helpers": "2.5.4" }, "optionalDependencies": { "@takumi-rs/core-darwin-arm64": "2.5.4", "@takumi-rs/core-darwin-x64": "2.5.4", "@takumi-rs/core-linux-arm64-gnu": "2.5.4", "@takumi-rs/core-linux-arm64-musl": "2.5.4", "@takumi-rs/core-linux-x64-gnu": "2.5.4", "@takumi-rs/core-linux-x64-musl": "2.5.4", "@takumi-rs/core-win32-arm64-msvc": "2.5.4", "@takumi-rs/core-win32-x64-msvc": "2.5.4" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-RfYVPihlYaa951bW2g7/lkK8uTQ3wxq1/yvY41K2CY98UZ8xChAcriJsF1Qxg1nAagmbLKuExJs1DSLR/+g9ow=="],
+    "@takumi-rs/core": ["@takumi-rs/core@2.5.10", "", { "dependencies": { "@takumi-rs/helpers": "2.5.10" }, "optionalDependencies": { "@takumi-rs/core-darwin-arm64": "2.5.10", "@takumi-rs/core-darwin-x64": "2.5.10", "@takumi-rs/core-linux-arm64-gnu": "2.5.10", "@takumi-rs/core-linux-arm64-musl": "2.5.10", "@takumi-rs/core-linux-x64-gnu": "2.5.10", "@takumi-rs/core-linux-x64-musl": "2.5.10", "@takumi-rs/core-win32-arm64-msvc": "2.5.10", "@takumi-rs/core-win32-x64-msvc": "2.5.10" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-aFm4nldCGXWMqfz6Kw+JZ79GkJuB8nKsP4uHseSPMI1GMUmQBqpwxYxTINe/CROoIfP4VMIkSZZ8jnx2KyGQmA=="],
 
-    "@takumi-rs/core-darwin-arm64": ["@takumi-rs/core-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gbIY8SBxWK2fg13OtXj6V4ONLN683tTR08Llhr/UNqGdMn5yLw26/inn9j4sQV52QCWzczUYMwSX7aE2CaTbcw=="],
+    "@takumi-rs/core-darwin-arm64": ["@takumi-rs/core-darwin-arm64@2.5.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1hq/mi+riaT77eToS/BJf0lBTX/jCUmnDqJgYyuq551D0JW0ArYJxnlehelFlReR8LeV3J/oqQgqXxrodeoDyg=="],
 
-    "@takumi-rs/core-darwin-x64": ["@takumi-rs/core-darwin-x64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-yQzah3bIo4SxFeQa+O/CBpMNc/FgbaDqMlzXA5/axRhypIXmdTaK9lrPqipROgPXRkPddeMevV1WoEHslaMCfg=="],
+    "@takumi-rs/core-darwin-x64": ["@takumi-rs/core-darwin-x64@2.5.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-JunN4oktWqiMlJ+Y+xDEyzG1xxr8f9ABb2+4G8xfK3/x6HHyrxon20bDmXd2Yjvh3xCiWm1TC5xFdcX0XX7NLg=="],
 
-    "@takumi-rs/core-linux-arm64-gnu": ["@takumi-rs/core-linux-arm64-gnu@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-eFtuebrAm+6W7BTn/revOgIJCp14n+Fomg5DgAvyiTa1fz9Cz4R/0Nlm9OBP/bXP+S2TTqTBVsqvivGjrLJCZg=="],
+    "@takumi-rs/core-linux-arm64-gnu": ["@takumi-rs/core-linux-arm64-gnu@2.5.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-2wRZToyZsSDZB3wLeUrbfDj7+eyUmasjcYdtXlxIIwNuQq39dbszazjKgNIG6E9JiUG7HWPUbZdzuc8tQpyDqA=="],
 
-    "@takumi-rs/core-linux-arm64-musl": ["@takumi-rs/core-linux-arm64-musl@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9JQEtQWOGkUYX7xPev6+TVZVNHpZlr0JOxyCCsaOKvwhyI2KLugWM8C+3CITRtqa0WfJOqJsM43UP3cFofFbvA=="],
+    "@takumi-rs/core-linux-arm64-musl": ["@takumi-rs/core-linux-arm64-musl@2.5.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-YYxTO1NstjoH+CzNvLVotgwLKE/l/Y4XA+5FkQIw7iyN7m5a7E24qQEE6Xp8Ew62x2kdrJHcYsAEOU461Ttwdg=="],
 
-    "@takumi-rs/core-linux-x64-gnu": ["@takumi-rs/core-linux-x64-gnu@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-KJp3tkS7BkwQ3WiKWse0uFjx/fKtsNayq9/sLo/8PurxZqjZAmIDMg4M9UUkWQ428uCTi+UERPNPlZQ/0XLrZQ=="],
+    "@takumi-rs/core-linux-x64-gnu": ["@takumi-rs/core-linux-x64-gnu@2.5.10", "", { "os": "linux", "cpu": "x64" }, "sha512-OTcYDjZ8MZTYEvpuVaPszNRiGG6H5kjeHr3qgCO/Ek4sldSDYlfKFjAABPeSSL+0sJvpExdQadeXVn0DKXCDhw=="],
 
-    "@takumi-rs/core-linux-x64-musl": ["@takumi-rs/core-linux-x64-musl@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-WRQSnGu91GqGlA64aCHi5MepROm5pnADo6x8o3AakNxLXu0R6Hb1Tj1qJLp4nSylImzZueyR7PUNhNr3xdEBpg=="],
+    "@takumi-rs/core-linux-x64-musl": ["@takumi-rs/core-linux-x64-musl@2.5.10", "", { "os": "linux", "cpu": "x64" }, "sha512-sowsR7EyxUO1uecFHVtD6V3I9fK1bvk15Gefmf8fnElQXCJF7Msi0/0g6PoIaRisWs1J8d+dOjEsVnS7KoxwIQ=="],
 
-    "@takumi-rs/core-win32-arm64-msvc": ["@takumi-rs/core-win32-arm64-msvc@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-BxtY3t4bk98mG4uS3Tao1p6U7zbKayH+KGgN7gYLkGTn3cKQtDxP/rwaebdOnnRycIDo310mzhJ5640JhDJBGQ=="],
+    "@takumi-rs/core-win32-arm64-msvc": ["@takumi-rs/core-win32-arm64-msvc@2.5.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-cfl4MJkpU+4y48uQSUYvkxICr+9PWLY4Mei++OxYlREaVVjIhWDV4C1VeWvoVOLbdYdxK4L6/Ywjn/+9BU/h2w=="],
 
-    "@takumi-rs/core-win32-x64-msvc": ["@takumi-rs/core-win32-x64-msvc@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-n3yNothzsg6+3CBOB53AKKWn9pa/z1X1TrFOM7tdBSvnnEjXdoeowx6IsNVBv/OunwWjw+ah2f9ldkry+8Q2hg=="],
+    "@takumi-rs/core-win32-x64-msvc": ["@takumi-rs/core-win32-x64-msvc@2.5.10", "", { "os": "win32", "cpu": "x64" }, "sha512-kg/pk74AG+ExV1jDEoJNrvHabBVhoj6a5r8tpSFlUUOz+njh8uspecoCq9GAzonPwURqEJSAgh1D+E8tHgNyqA=="],
 
-    "@takumi-rs/helpers": ["@takumi-rs/helpers@2.5.4", "", { "peerDependencies": { "preact": "^10.0.0", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["preact", "react"] }, "sha512-/bNTK2nRSmaugF4m2TDb1SLiEAN7PcORwqqa1RIfahMAqxZoNzMw2krCuNexeDRPGBNJKNCmlOB6F1heBXqHTw=="],
+    "@takumi-rs/helpers": ["@takumi-rs/helpers@2.5.10", "", { "peerDependencies": { "preact": "^10.0.0", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["preact", "react"] }, "sha512-bg+DUcJ5nKsB62Z4MH/sj6tyc32GlzEj8m9Q30A/WV8RYfvFygVVOfpYFMbJvmr+SxhPfTxDxLfIIktGCM8fQA=="],
 
-    "@takumi-rs/wasm": ["@takumi-rs/wasm@2.5.4", "", { "dependencies": { "@takumi-rs/helpers": "2.5.4" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-Uae6J+SglHS2sl0hqXLGuw5nUEy/scyYOJzbGFfN79EGm+Oy5f5SkizlNKo+6H0HzWoXCNdWCvXq/Yl8stRylA=="],
+    "@takumi-rs/wasm": ["@takumi-rs/wasm@2.5.10", "", { "dependencies": { "@takumi-rs/helpers": "2.5.10" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-e8T4NGyfbqHyfwRVUYckSlT2vLZD4JEkcrCsaQGOxmcoVg4kqTu6CXDoJ+51OxdbG9jauWu2jLGm+/9EPzQLug=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -662,11 +662,11 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "fumadocs-core": ["fumadocs-core@16.14.0", "", { "dependencies": { "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "hast-util-to-estree": "^3.1.3", "hast-util-to-jsx-runtime": "^2.3.6", "mdast-util-mdx": "^3.0.0", "mdast-util-to-markdown": "^2.1.2", "npm-to-yarn": "3.2.0", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "remark-rehype": "^11.1.2", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.3.1", "tinyglobby": "^0.2.17", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3", "yaml": "^2.9.0", "zbsearch": "^3.3.4" }, "peerDependencies": { "@mdx-js/mdx": "*", "@mixedbread/sdk": "0.x.x", "@orama/core": "1.x.x", "@oramacloud/client": "2.x.x", "@tanstack/react-router": "1.x.x", "@types/estree-jsx": "*", "@types/hast": "*", "@types/mdast": "*", "@types/react": "*", "algoliasearch": "5.x.x", "flexsearch": "*", "lucide-react": "*", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "react-router": "7.x.x || 8.x.x", "waku": "*", "zod": "4.x.x" }, "optionalPeers": ["@mdx-js/mdx", "@mixedbread/sdk", "@orama/core", "@oramacloud/client", "@tanstack/react-router", "@types/estree-jsx", "@types/hast", "@types/mdast", "@types/react", "algoliasearch", "flexsearch", "lucide-react", "next", "react", "react-dom", "react-router", "waku", "zod"] }, "sha512-CQBsVm2XoxytoK5iTxd2Q3L76XBXY9yrWdThH9iJxZPcZ4aHED7YJCYuHPHZDIWg80fy1UAgVc6ogfE+24jTDA=="],
+    "fumadocs-core": ["fumadocs-core@16.14.1", "", { "dependencies": { "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "hast-util-to-estree": "^3.1.3", "hast-util-to-jsx-runtime": "^2.3.6", "mdast-util-mdx": "^3.0.0", "mdast-util-to-markdown": "^2.1.2", "npm-to-yarn": "3.2.0", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "remark-rehype": "^11.1.2", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.4.1", "tinyglobby": "^0.2.17", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3", "yaml": "^2.9.0", "zbsearch": "^3.3.4" }, "peerDependencies": { "@mdx-js/mdx": "*", "@mixedbread/sdk": "0.x.x", "@orama/core": "1.x.x", "@oramacloud/client": "2.x.x", "@tanstack/react-router": "1.x.x", "@types/estree-jsx": "*", "@types/hast": "*", "@types/mdast": "*", "@types/react": "*", "algoliasearch": "5.x.x", "flexsearch": "*", "lucide-react": "*", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "react-router": "7.x.x || 8.x.x", "waku": "*", "zod": "4.x.x" }, "optionalPeers": ["@mdx-js/mdx", "@mixedbread/sdk", "@orama/core", "@oramacloud/client", "@tanstack/react-router", "@types/estree-jsx", "@types/hast", "@types/mdast", "@types/react", "algoliasearch", "flexsearch", "lucide-react", "next", "react", "react-dom", "react-router", "waku", "zod"] }, "sha512-Bhyd0J8gMWtX9o1eFvR/9/Cc0/5Al/jMIf4ukeNtHhjRCkT0fXsPFXiFgKPtWMBdKpffx9WRbVewtcc0py0rnw=="],
 
-    "fumadocs-mdx": ["fumadocs-mdx@15.2.1", "", { "dependencies": { "@mdx-js/mdx": "^3.1.1", "@standard-schema/spec": "^1.1.0", "chokidar": "^5.0.0", "esbuild": "^0.28.1", "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "magic-string": "^1.1.0", "mdast-util-mdx": "^3.0.0", "picocolors": "^1.1.1", "picomatch": "^4.0.5", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3", "yaml": "^2.9.0", "yuku-analyzer": "^0.8.1", "zod": "^4.4.3" }, "peerDependencies": { "@fumadocs/satteri": "0.x.x", "@types/mdast": "*", "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "^16.7.0", "mdast-util-directive": "*", "next": "^15.3.0 || ^16.0.0", "react": "^19.2.0", "rolldown": "*", "satteri": "^0.9.4", "vite": "7.x.x || 8.x.x" }, "optionalPeers": ["@fumadocs/satteri", "@types/mdast", "@types/mdx", "@types/react", "mdast-util-directive", "next", "react", "rolldown", "satteri", "vite"], "bin": { "fumadocs-mdx": "./bin.js" } }, "sha512-lyx35MAFAj9yuLPudNoRGGvauZlT1xRLLw17P0jnvhXikrJNC8mAeg/4WIity5K+3V6ZetBQ2PYIcnli450vMg=="],
+    "fumadocs-mdx": ["fumadocs-mdx@15.2.2", "", { "dependencies": { "@mdx-js/mdx": "^3.1.1", "@standard-schema/spec": "^1.1.0", "chokidar": "^5.0.0", "esbuild": "^0.28.1", "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "magic-string": "^1.1.0", "mdast-util-mdx": "^3.0.0", "picocolors": "^1.1.1", "picomatch": "^4.0.5", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3", "yaml": "^2.9.0", "yuku-analyzer": "^0.8.1", "zod": "^4.4.3" }, "peerDependencies": { "@fumadocs/satteri": "0.x.x", "@types/mdast": "*", "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "^16.7.0", "mdast-util-directive": "*", "next": "^15.3.0 || ^16.0.0", "react": "^19.2.0", "rolldown": "*", "satteri": "^0.9.4", "vite": "7.x.x || 8.x.x" }, "optionalPeers": ["@fumadocs/satteri", "@types/mdast", "@types/mdx", "@types/react", "mdast-util-directive", "next", "react", "rolldown", "satteri", "vite"], "bin": { "fumadocs-mdx": "./bin.js" } }, "sha512-cWtGFSDSWOTykuxym3uzfuIkK9oWyNcAeIWgjqfS1QbkrY9nAh9fmoPCFwMcw7alk5oX5l8sxvRsUG+ZTuShNQ=="],
 
-    "fumadocs-ui": ["@fumadocs/base-ui@16.14.0", "", { "dependencies": { "@base-ui/react": "^1.6.0", "@fuma-translate/react": "^1.0.2", "@fumadocs/tailwind": "0.1.1", "class-variance-authority": "^0.7.1", "cnfast": "^0.1.0", "lucide-react": "^1.27.0", "motion": "^12.43.0", "next-themes": "^0.4.6", "react-remove-scroll": "^2.7.2", "rehype-raw": "^7.0.0", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.3.1", "unist-util-visit": "^5.1.0" }, "peerDependencies": { "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "16.14.0", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "takumi-js": "*" }, "optionalPeers": ["@types/mdx", "@types/react", "next", "takumi-js"] }, "sha512-mJ0PVUtKGr/PdwIb3S0CYgUr+U5RxQ+SwnaM+m4yxl7MvVyvaP4DMtU791POOVzF3tYpYa0xEEp1CQjM6A0r5w=="],
+    "fumadocs-ui": ["@fumadocs/base-ui@16.14.1", "", { "dependencies": { "@base-ui/react": "^1.7.0", "@fuma-translate/react": "^1.0.2", "@fumadocs/tailwind": "0.1.1", "class-variance-authority": "^0.7.1", "cnfast": "^0.1.0", "lucide-react": "^1.28.0", "motion": "^12.43.0", "next-themes": "^0.4.6", "react-remove-scroll": "^2.7.2", "rehype-raw": "^7.0.0", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.4.1", "unist-util-visit": "^5.1.0" }, "peerDependencies": { "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "16.14.1", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "takumi-js": "*" }, "optionalPeers": ["@types/mdx", "@types/react", "next", "takumi-js"] }, "sha512-S1CAMPX1LxHxciBO08jcj2h8h5ShU3z61s+47GQY1ODJVBI62rzhzw+2q+1ruEzmUv7NPqvY6/D8cwWe/A8+Ww=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -754,7 +754,7 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
-    "lucide-react": ["lucide-react@1.28.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg=="],
+    "lucide-react": ["lucide-react@1.29.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg=="],
 
     "magic-string": ["magic-string@1.1.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g=="],
 
@@ -1012,7 +1012,7 @@
 
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
-    "takumi-js": ["takumi-js@2.5.4", "", { "dependencies": { "@takumi-rs/core": "2.5.4", "@takumi-rs/helpers": "2.5.4", "@takumi-rs/wasm": "2.5.4" } }, "sha512-GdzRCezKVelmjfh/J5vsEtYUeEgoKMRtwe57f7Qd4XrPdMCkYvWl8ThuHZ67J76bMqGpHUEDZATkgu8RYbTwSg=="],
+    "takumi-js": ["takumi-js@2.5.10", "", { "dependencies": { "@takumi-rs/core": "2.5.10", "@takumi-rs/helpers": "2.5.10", "@takumi-rs/wasm": "2.5.10" } }, "sha512-P5DDKW5u06kumyedEyHijgMm2seyvkunqnm7ATTEW7GgsRkIAt3mPz2qVR3KGrq8vhL5Yjcxjt4pH9RrlzV0cw=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -1078,7 +1078,7 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
+    "vite": ["vite@8.2.1", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.25", "rolldown": "~1.2.1", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
@@ -1138,13 +1138,13 @@
 
     "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
-    "fumadocs-mdx/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
-
     "knip/get-tsconfig": ["get-tsconfig@4.14.1", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "waku/vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@2.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ=="],
 

--- a/docs/content/docs/comparing-analyses.mdx
+++ b/docs/content/docs/comparing-analyses.mdx
@@ -15,7 +15,6 @@ const high = tileTracker();
 const low = tileTracker();
 
 await analyzePGN('<pathToPgnFile>', {
-    workers: false,
     headers: true,
     runs: [
         {
@@ -42,4 +41,4 @@ const heatmapData = generateComparisonHeatmap(high.state, low.state, compareFunc
 
 `generateComparisonHeatmap` builds two heatmaps from the same analysis function and returns per-cell percentage differences.
 
-Pass **distinct instances** for each cohort (`tileTracker()` twice) — the same instance cannot appear more than once in one `analyzePGN` call. Because filters require the main thread, pass `workers: false`. See [Filters](/docs/filters) and [Heatmaps](/docs/heatmaps).
+Pass **distinct instances** for each cohort (`tileTracker()` twice) — the same instance cannot appear more than once in one `analyzePGN` call. Filters run on the main thread (single-threaded automatically). See [Filters](/docs/filters) and [Heatmaps](/docs/heatmaps).

--- a/docs/content/docs/filters.mdx
+++ b/docs/content/docs/filters.mdx
@@ -12,7 +12,6 @@ import { tileTracker } from 'chessalyzer/trackers';
 const tiles = tileTracker();
 
 await analyzePGN('<pathToPgnFile>', {
-    workers: false,
     trackers: [tiles],
     filter: (game) => Number(game.headers?.WhiteElo) > 2000,
 });
@@ -22,7 +21,7 @@ console.log(tiles.state.movesTotal);
 
 ## Requirements
 
-- **`workers: false`** — filters are regular JS callbacks and must run on the main thread. The library will let you know if you forget.
+- Filters are regular JS callbacks and run on the main thread. When a `filter` is present, analysis is single-threaded automatically (`workers` may be omitted or set to `false`). Passing an explicit worker pool with a filter is an error.
 
 Tag-pair headers are parsed automatically when a filter is present (so `game.headers` is populated). Set `headers: false` only when your filter does not read headers.
 

--- a/docs/content/docs/multithreading.mdx
+++ b/docs/content/docs/multithreading.mdx
@@ -32,12 +32,9 @@ Pass `workers: false` when you need everything on the main thread:
 await analyzePGN('<pathToPgnFile>', { workers: false });
 ```
 
-**Required when using:**
+A JavaScript [`filter`](/docs/filters) callback also forces single-threaded analysis — omit `workers` or pass `workers: false`. Combining a filter with an explicit worker pool is an error.
 
-- A JavaScript [`filter`](/docs/filters) callback
-- Some [custom tracker](/docs/trackers/custom) setups during development
-
-The library validates this and will tell you if you forget.
+Some [custom tracker](/docs/trackers/custom) setups during development may also need `workers: false`.
 
 ## Custom trackers in multithreaded mode
 

--- a/docs/content/docs/trackers/custom.mdx
+++ b/docs/content/docs/trackers/custom.mdx
@@ -129,4 +129,4 @@ import { defineGameTracker, defineMoveTracker } from 'chessalyzer/trackers';
 
 See [`manual-tests/custom-game-tracker.ts`](https://github.com/yschroe/chessalyzer/blob/main/manual-tests/custom-game-tracker.ts) for a minimal working example.
 
-When using custom trackers with filters, pass `workers: false`. See [Multithreading](/docs/multithreading).
+When using custom trackers with filters, analysis is single-threaded (omit `workers` or pass `workers: false`). See [Multithreading](/docs/multithreading).

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,14 +12,14 @@
         "lint": "oxlint"
     },
     "dependencies": {
-        "fumadocs-core": "16.14.0",
-        "fumadocs-mdx": "15.2.1",
-        "fumadocs-ui": "npm:@fumadocs/base-ui@16.14.0",
-        "lucide-react": "^1.28.0",
+        "fumadocs-core": "16.14.1",
+        "fumadocs-mdx": "15.2.2",
+        "fumadocs-ui": "npm:@fumadocs/base-ui@16.14.1",
+        "lucide-react": "^1.29.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-server-dom-webpack": "^19.2.8",
-        "takumi-js": "^2.5.4",
+        "takumi-js": "^2.5.10",
         "use-sync-external-store": "^1.6.0",
         "waku": "1.0.0-beta.8"
     },
@@ -31,6 +31,6 @@
         "@types/react-dom": "^19.2.4",
         "tailwindcss": "^4.3.3",
         "typescript": "^6.0.3",
-        "vite": "^8.2.0"
+        "vite": "^8.2.1"
     }
 }

--- a/manual-tests/playground.ts
+++ b/manual-tests/playground.ts
@@ -1,0 +1,23 @@
+import { analyzePGN } from 'chessalyzer';
+import { tileTracker } from 'chessalyzer/trackers';
+
+/*
+ * Basic example of analyzing a PGN file. In the most simple form (no filters, no trackers),
+ * it will only return a summary of the games in the PGN file.
+ */
+
+const result = await analyzePGN('pgn/asorted-games.pgn');
+console.log(result);
+
+const result2 = await analyzePGN('pgn/asorted-games.pgn', {
+    filter: (game) => Number(game.headers?.WhiteElo ?? 0) > 1500,
+});
+console.log(result2);
+
+const tiles = tileTracker();
+const result3 = await analyzePGN('pgn/asorted-games.pgn', {
+    filter: (game) => Number(game.headers?.WhiteElo ?? 0) > 1500,
+    trackers: [tiles],
+});
+console.log(result3);
+console.log(tiles.state);

--- a/package.json
+++ b/package.json
@@ -84,14 +84,14 @@
     "devDependencies": {
         "@types/bun": "^1.3.14",
         "@types/node": "^26.1.2",
-        "bumpp": "^12.1.1",
+        "bumpp": "^12.2.0",
         "bun-plugin-dts": "^0.4.0",
-        "knip": "^6.31.0",
+        "knip": "^6.32.0",
         "oxfmt": "^0.62.0",
         "oxlint": "^1.77.0",
         "oxlint-tsgolint": "^7.0.2001",
         "tinybench": "^6.1.2",
-        "tsx": "^4.23.5",
+        "tsx": "^4.23.9",
         "typescript": "6.0.3"
     },
     "overrides": {

--- a/src/core/__tests__/analysis-config.test.ts
+++ b/src/core/__tests__/analysis-config.test.ts
@@ -29,10 +29,10 @@ describe('normalizeAnalyzeOptions', () => {
         ).toThrow('Cannot set both runs and top-level trackers');
     });
 
-    it('rejects filter without workers: false', () => {
-        expect(() =>
-            normalizeAnalyzeOptions(invalidAnalyzeOptions({ filter: () => true })),
-        ).toThrow('filter requires workers: false');
+    it('uses single-threaded mode when filter is set and workers omitted', () => {
+        const { configs, multithreadCfg } = normalizeAnalyzeOptions({ filter: () => true });
+        expect(multithreadCfg).toBeNull();
+        expect(configs[0]?.limits.filter).toBeDefined();
     });
 
     it('allows filter with workers: false', () => {
@@ -44,18 +44,33 @@ describe('normalizeAnalyzeOptions', () => {
         expect(configs[0]?.limits.filter).toBeDefined();
     });
 
-    it('rejects filter in multi-run without workers: false', () => {
+    it('rejects filter with an explicit worker pool', () => {
+        expect(() =>
+            normalizeAnalyzeOptions(invalidAnalyzeOptions({ filter: () => true, workers: 4 })),
+        ).toThrow('filter cannot be used with worker threads');
+    });
+
+    it('uses single-threaded mode for multi-run filters when workers omitted', () => {
+        const { multithreadCfg, configs } = normalizeAnalyzeOptions({
+            runs: [{ filter: () => true }, { trackers: [tileTracker()] }],
+        });
+        expect(multithreadCfg).toBeNull();
+        expect(configs).toHaveLength(2);
+    });
+
+    it('rejects multi-run filter with an explicit worker pool', () => {
         expect(() =>
             normalizeAnalyzeOptions(
                 invalidAnalyzeOptions({
+                    workers: { count: 2 },
                     runs: [{ filter: () => true }, { trackers: [tileTracker()] }],
                 }),
             ),
-        ).toThrow('filter requires workers: false');
+        ).toThrow('filter cannot be used with worker threads');
     });
 
     it('parses headers when a filter is present', () => {
-        const { parseHeaders } = normalizeAnalyzeOptions({ workers: false, filter: () => true });
+        const { parseHeaders } = normalizeAnalyzeOptions({ filter: () => true });
         expect(parseHeaders).toBe(true);
     });
 

--- a/src/core/analysis-config.ts
+++ b/src/core/analysis-config.ts
@@ -35,20 +35,6 @@ function resolveParseHeaders(
     return needsHeaders;
 }
 
-/** Assert that a filter requires workers: false. */
-function assertFilterRequiresSingleThreaded(
-    runs: AnalyzeRun[],
-    multithreadCfg: WorkerOptions | null,
-): void {
-    if (multithreadCfg === null) return;
-    const hasFilter = runs.some((run) => run.filter !== undefined);
-    if (hasFilter) {
-        throw new Error(
-            'A JavaScript filter requires workers: false — filter predicates run on the main thread and cannot be used with the default worker pool',
-        );
-    }
-}
-
 /** Assert that no conflicting run fields are set. */
 function assertNoConflictingRunFields(opts: AnalyzeOptions): void {
     if (opts.trackers !== undefined) {
@@ -78,8 +64,21 @@ function resolveRuns(opts: AnalyzeOptions): AnalyzeRun[] {
     return [{ trackers: single.trackers, filter: single.filter, maxGames: single.maxGames }];
 }
 
-/** Resolve `workers` option to multithread config or `null` for single-threaded. */
-function resolveMultithreadCfg(workers: AnalyzeOptions['workers']): WorkerOptions | null {
+/**
+ * Resolve `workers` to multithread config or `null` for single-threaded.
+ * A filter implies single-threaded when `workers` is omitted; an explicit
+ * worker pool with a filter is a conflict.
+ */
+function resolveMultithreadCfg(
+    workers: AnalyzeOptions['workers'],
+    hasFilter: boolean,
+): WorkerOptions | null {
+    if (hasFilter) {
+        if (workers === undefined || workers === false) return null;
+        throw new Error(
+            'A JavaScript filter cannot be used with worker threads — omit workers or pass workers: false (filter predicates run on the main thread)',
+        );
+    }
     if (workers === false) return null;
     if (typeof workers === 'number') return { count: workers };
     return workers ?? {};
@@ -90,13 +89,10 @@ function resolveMultithreadCfg(workers: AnalyzeOptions['workers']): WorkerOption
  * validates, then builds per-run runtime state and path-selection fields.
  */
 export function normalizeAnalyzeOptions(options: AnalyzeOptions = {}): NormalizedAnalyzeOptions {
-    const multithreadCfg = resolveMultithreadCfg(options.workers);
-
     // Resolve runs into per-run configs, converting single-run sugar.
     const runs = resolveRuns(options);
-    assertFilterRequiresSingleThreaded(runs, multithreadCfg);
-
     const hasFilter = runs.some((run) => run.filter !== undefined);
+    const multithreadCfg = resolveMultithreadCfg(options.workers, hasFilter);
     const multithreaded = multithreadCfg !== null;
     let needsHeaders = false;
     const configs: GameProcessorConfig[] = [];

--- a/src/core/analyze.ts
+++ b/src/core/analyze.ts
@@ -10,10 +10,7 @@ import GameProcessor from '#core/game-processor';
 import type {
     AnalyzeOptions,
     AnalyzeResult,
-    AnalyzeRun,
     AnalyzeRunResult,
-    MultiRunOptions,
-    MultiRunOptionsMT,
     SingleRunOptions,
 } from '#types/analysis';
 import type { AnalyzeError } from '#types/errors';
@@ -88,7 +85,6 @@ export function buildAnalyzeResult(
 }
 
 type TrackerList = readonly TrackerInstance[];
-type AnalyzeRunNoFilter = Omit<AnalyzeRun, 'filter'> & { filter?: never };
 
 /**
  * Analyze a PGN file with optional trackers, filters, and worker configuration.
@@ -96,6 +92,9 @@ type AnalyzeRunNoFilter = Omit<AnalyzeRun, 'filter'> & { filter?: never };
  * Pass tracker instances from factory calls (e.g. `tileTracker()`). Accumulated
  * state is available on the same instances after the call returns (`tiles.state`).
  * The returned {@link AnalyzeResult} holds throughput and per-run counts only.
+ *
+ * A JavaScript `filter` implies single-threaded analysis (workers are omitted
+ * or `workers: false`). Combining a filter with an explicit worker pool throws.
  *
  * @example
  * ```ts
@@ -110,14 +109,6 @@ type AnalyzeRunNoFilter = Omit<AnalyzeRun, 'filter'> & { filter?: never };
 export function analyzePGN<const T extends TrackerList>(
     path: string,
     options?: SingleRunOptions<T>,
-): Promise<AnalyzeResult>;
-export function analyzePGN<const R extends readonly [AnalyzeRun, ...AnalyzeRun[]]>(
-    path: string,
-    options: MultiRunOptions<R>,
-): Promise<AnalyzeResult>;
-export function analyzePGN<const R extends readonly [AnalyzeRunNoFilter, ...AnalyzeRunNoFilter[]]>(
-    path: string,
-    options: MultiRunOptionsMT<R>,
 ): Promise<AnalyzeResult>;
 export function analyzePGN(path: string, options?: AnalyzeOptions): Promise<AnalyzeResult>;
 export async function analyzePGN(path: string, options?: AnalyzeOptions): Promise<AnalyzeResult> {

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -85,11 +85,11 @@ type MultiRunBase<R extends readonly AnalyzeRunBase[]> = SharedAnalyzeFields<All
 };
 
 /** Multi-run options when any run may include a filter (`workers` omitted or `false`). */
-export type MultiRunOptions<R extends readonly [AnalyzeRunWithFilter, ...AnalyzeRunWithFilter[]]> =
+type MultiRunOptionsST<R extends readonly [AnalyzeRunWithFilter, ...AnalyzeRunWithFilter[]]> =
     MultiRunBase<R> & { workers?: false };
 
 /** Multi-run options with no filters (default worker pool allowed). */
-export type MultiRunOptionsMT<R extends readonly [AnalyzeRunNoFilter, ...AnalyzeRunNoFilter[]]> =
+type MultiRunOptionsMT<R extends readonly [AnalyzeRunNoFilter, ...AnalyzeRunNoFilter[]]> =
     MultiRunBase<R> & { workers?: WorkerOptions | number | false };
 
 /**
@@ -98,7 +98,7 @@ export type MultiRunOptionsMT<R extends readonly [AnalyzeRunNoFilter, ...Analyze
  */
 export type AnalyzeOptions =
     | SingleRunOptions
-    | MultiRunOptions<readonly [AnalyzeRunWithFilter, ...AnalyzeRunWithFilter[]]>
+    | MultiRunOptionsST<readonly [AnalyzeRunWithFilter, ...AnalyzeRunWithFilter[]]>
     | MultiRunOptionsMT<readonly [AnalyzeRunNoFilter, ...AnalyzeRunNoFilter[]]>;
 
 /** Per-run counters returned from `analyzePGN`. Tracker state lives on the instances you passed in. */

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -3,7 +3,12 @@ import type { AnalyzeError } from '#types/errors';
 import type { ParsedGame } from '#types/parse-pgn';
 import type { TrackerInstance } from '#types/tracker';
 
-/** Per-game predicate for single-threaded analysis (`workers: false` only). */
+/**
+ * Per-game predicate for analysis.
+ * Closures cannot run on worker threads — when a filter is set, analysis is
+ * single-threaded (`workers` omitted or `workers: false`). Explicit worker
+ * pool options with a filter are a type and runtime error.
+ */
 export type GameFilter = (game: ParsedGame) => boolean;
 
 type TrackerList = readonly TrackerInstance[];
@@ -36,8 +41,10 @@ export interface WorkerOptions {
     chunk?: WorkerChunkOptions;
 }
 
-type SingleThreadedWorkers = { workers: false };
-type MultithreadedWorkers = { workers?: WorkerOptions | number; filter?: never };
+/** Filter present → single-threaded (`workers` omitted or explicitly `false`). */
+type WithFilter = { filter: GameFilter; workers?: false };
+/** No filter → default worker pool, or `workers: false` for explicit single-threaded. */
+type WithoutFilter = { filter?: never; workers?: WorkerOptions | number | false };
 
 type SharedAnalyzeFields<I> = {
     headers?: HeadersForInstances<I>;
@@ -54,7 +61,7 @@ interface AnalyzeRunBase {
 type AnalyzeRunWithFilter = AnalyzeRunBase & { filter?: GameFilter };
 type AnalyzeRunNoFilter = AnalyzeRunBase & { filter?: never };
 
-/** Options for one analysis run (filter allowed — requires `workers: false` on the call). */
+/** Options for one analysis run (optional filter — implies single-threaded on the call). */
 export type AnalyzeRun = AnalyzeRunWithFilter;
 
 /** Single-run `analyzePGN` options (top-level `trackers` / `filter` / `maxGames` sugar). */
@@ -64,31 +71,26 @@ export type SingleRunOptions<T extends TrackerList = TrackerInstance[]> = Shared
     trackers?: T;
     maxGames?: number;
     runs?: never;
-} & ((SingleThreadedWorkers & { filter?: GameFilter }) | MultithreadedWorkers);
+} & (WithFilter | WithoutFilter);
 
 type AllRunInstances<R extends readonly AnalyzeRunBase[]> = NonNullable<
     R[number]['trackers']
 >[number];
 
-/** Multi-run `analyzePGN` options when `workers: false` (per-run filters allowed). */
-export type MultiRunOptions<R extends readonly [AnalyzeRunWithFilter, ...AnalyzeRunWithFilter[]]> =
-    SharedAnalyzeFields<AllRunInstances<R>> &
-        SingleThreadedWorkers & {
-            runs: R;
-            trackers?: never;
-            filter?: never;
-            maxGames?: never;
-        };
+type MultiRunBase<R extends readonly AnalyzeRunBase[]> = SharedAnalyzeFields<AllRunInstances<R>> & {
+    runs: R;
+    trackers?: never;
+    filter?: never;
+    maxGames?: never;
+};
 
-/** Multi-run `analyzePGN` options with the default worker pool (no filters). */
+/** Multi-run options when any run may include a filter (`workers` omitted or `false`). */
+export type MultiRunOptions<R extends readonly [AnalyzeRunWithFilter, ...AnalyzeRunWithFilter[]]> =
+    MultiRunBase<R> & { workers?: false };
+
+/** Multi-run options with no filters (default worker pool allowed). */
 export type MultiRunOptionsMT<R extends readonly [AnalyzeRunNoFilter, ...AnalyzeRunNoFilter[]]> =
-    SharedAnalyzeFields<AllRunInstances<R>> &
-        MultithreadedWorkers & {
-            runs: R;
-            trackers?: never;
-            filter?: never;
-            maxGames?: never;
-        };
+    MultiRunBase<R> & { workers?: WorkerOptions | number | false };
 
 /**
  * Options passed to `analyzePGN`: shared fields plus either a single run

--- a/test/integration/fixtures.test.ts
+++ b/test/integration/fixtures.test.ts
@@ -75,19 +75,19 @@ describe('Fixtures', () => {
         it('filters by result (single-threaded)', async () => {
             const data = await analyzePGN(fixturePath('results-mix'), {
                 filter: (game: ParsedGame) => game.result === '1-0',
-                workers: false,
             });
             expect(data.gameCount).toBe(3);
         });
 
-        it('rejects filter without workers: false', () => {
+        it('rejects filter with an explicit worker pool', () => {
             const options = {
                 filter: (game: ParsedGame) => game.result === '1-0',
+                workers: 2,
             };
 
             // @ts-expect-error - test case
             expect(analyzePGN(fixturePath('results-mix'), options)).rejects.toThrow(
-                'filter requires workers: false',
+                'filter cannot be used with worker threads',
             );
         });
 
@@ -95,7 +95,6 @@ describe('Fixtures', () => {
             const data = await analyzePGN(fixturePath('results-mix'), {
                 maxGames: 2,
                 filter: (game: ParsedGame) => game.result === '0-1',
-                workers: false,
             });
             expect(data.gameCount).toBe(2);
         });

--- a/test/types/api.type-test.ts
+++ b/test/types/api.type-test.ts
@@ -17,6 +17,10 @@ async function validSingleRun() {
 async function validFilteredRun() {
     const tiles = tileTracker();
     await analyzePGN('x', {
+        trackers: [tiles],
+        filter: (game) => game.result === '1-0',
+    });
+    await analyzePGN('x', {
         workers: false,
         trackers: [tiles],
         filter: (game) => game.result === '1-0',
@@ -27,7 +31,6 @@ async function validMultiRun() {
     const blackWins = tileTracker();
     const whiteWins = tileTracker();
     await analyzePGN('x', {
-        workers: false,
         runs: [
             { trackers: [blackWins], filter: (game) => game.result === '0-1' },
             { trackers: [whiteWins], filter: (game) => game.result === '1-0' },
@@ -56,8 +59,8 @@ async function invalidConfigs() {
     const tiles = tileTracker();
     const games = gameTracker();
 
-    // @ts-expect-error filter requires workers: false
-    await analyzePGN('x', { trackers: [games], filter: () => true });
+    // @ts-expect-error filter cannot combine with an explicit worker pool
+    await analyzePGN('x', { trackers: [games], filter: () => true, workers: 4 });
 
     // @ts-expect-error cannot set both runs and top-level trackers
     await analyzePGN('x', { runs: [{ trackers: [tiles] }], trackers: [games] });
@@ -65,8 +68,11 @@ async function invalidConfigs() {
     // @ts-expect-error runs must be non-empty
     await analyzePGN('x', { runs: [] });
 
-    // @ts-expect-error filter in multi-run requires workers: false
-    await analyzePGN('x', { runs: [{ filter: () => true, trackers: [tiles] }] });
+    // @ts-expect-error filter in multi-run cannot combine with an explicit worker pool
+    await analyzePGN('x', {
+        workers: { count: 2 },
+        runs: [{ filter: () => true, trackers: [tiles] }],
+    });
 
     const noMerge = defineGameTracker({
         id: 'no-merge',


### PR DESCRIPTION
- Simplify analyzePGN overloads which now only has a separate overload for the single-run sugar
- Remove the need for users to manually set `workers: false` when a filter predicate is passed -> is now handled internally