### PR TITLE
test: split fixture test file into sub-files; add MT and ST test split

### DIFF
--- a/scripts/build-fixture-manifest.ts
+++ b/scripts/build-fixture-manifest.ts
@@ -21,7 +21,8 @@ const descriptions: Record<string, string> = {
     'en-passant': 'Game containing an en passant capture',
     promotion: 'Game with a pawn promotion',
     'multiple-promotions': 'Game with multiple pawn promotions',
-    corrupt: 'One complete game plus one truncated game at EOF',
+    corrupt:
+        'One complete game plus one truncated game at EOF (incomplete game dropped at parse; not counted in skippedGames)',
     'white-wins': 'Short game ending 1-0',
     'black-wins': 'Short game ending 0-1',
     draw: 'Short game ending 1/2-1/2',

--- a/scripts/build-fixture-manifest.ts
+++ b/scripts/build-fixture-manifest.ts
@@ -1,17 +1,16 @@
 /**
  * Analyzes committed test/fixtures/*.pgn and merges results into test/fixtures/manifest.json.
- * Preserves golden values and manual entries; per-fixture analyze overrides handle error fixtures.
+ * Preserves golden values and existing descriptions when regenerating expected counts.
  *
  * Run after adding or changing fixture PGNs: bun run test:build-fixtures
  *
- * Uses single-threaded mode for deterministic analysis.
+ * Uses single-threaded mode for deterministic analysis (no trackers — parse/count smoke only).
  */
 import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { analyzePGN } from '#core/analyze';
-import type { AnalyzeOptions } from '#types/analysis';
 
 const FIXTURES_DIR = fileURLToPath(new URL('../test/fixtures/', import.meta.url));
 const MANIFEST_PATH = join(FIXTURES_DIR, 'manifest.json');
@@ -22,7 +21,7 @@ const descriptions: Record<string, string> = {
     promotion: 'Game with a pawn promotion',
     'multiple-promotions': 'Game with multiple pawn promotions',
     corrupt:
-        'One complete game plus one truncated game at EOF (incomplete game dropped at parse; not counted in skippedGames)',
+        'One complete game plus one truncated game at EOF (incomplete trailing game dropped at parse)',
     'white-wins': 'Short game ending 1-0',
     'black-wins': 'Short game ending 0-1',
     draw: 'Short game ending 1/2-1/2',
@@ -34,22 +33,15 @@ const descriptions: Record<string, string> = {
     'crlf-endings': 'Two complete games with CRLF line endings',
 };
 
-/** Per-fixture analyze options, or `manual` to keep the existing manifest entry unchanged. */
-const FIXTURE_ANALYZE: Record<string, AnalyzeOptions | 'manual'> = {
-    'bad-san-mid-file': { onError: 'skip-game', workers: false },
-};
-
 interface ManifestExpected {
     games: number;
     moves: number;
-    skippedGames?: number;
 }
 
 interface ManifestFixture {
     file: string;
     description: string;
     expected: ManifestExpected;
-    analyzeOptions?: AnalyzeOptions;
     golden?: Record<string, unknown>;
 }
 
@@ -68,16 +60,6 @@ async function loadExistingManifest(): Promise<Manifest> {
     }
 }
 
-/** Options stored in manifest (workers are always false in the build script). */
-function manifestAnalyzeOptions(
-    policy: AnalyzeOptions | 'manual' | undefined,
-): AnalyzeOptions | undefined {
-    if (!policy || policy === 'manual') return undefined;
-    const { workers: _workers, ...rest } = policy;
-    if (Object.keys(rest).length === 0) return undefined;
-    return { workers: false, ...rest };
-}
-
 const existing = await loadExistingManifest();
 const fixtures: Record<string, ManifestFixture> = {};
 let hadError = false;
@@ -88,44 +70,21 @@ for (const file of files) {
     const id = file.replace(/\.pgn$/, '');
     const path = join(FIXTURES_DIR, file);
     const prior = existing.fixtures[id];
-    const policy = FIXTURE_ANALYZE[id];
-
-    if (policy === 'manual') {
-        if (!prior) {
-            console.error(`${id}: marked manual but missing from manifest.json`);
-            hadError = true;
-            continue;
-        }
-        fixtures[id] = { ...prior, file };
-        console.log(`${id}: kept manual entry (${prior.expected.games} games)`);
-        continue;
-    }
-
-    const analyzeOpts: AnalyzeOptions = { workers: false, ...policy };
 
     try {
         // oxlint-disable-next-line eslint/no-await-in-loop -- sequential fixture analysis for readable logs and lower memory use
-        const result = await analyzePGN(path, analyzeOpts);
-        const expected: ManifestExpected = {
-            games: result.gameCount,
-            moves: result.moveCount,
-        };
-        if ((result.skippedGames ?? 0) > 0) {
-            expected.skippedGames = result.skippedGames;
-        }
-
+        const result = await analyzePGN(path, { workers: false });
         fixtures[id] = {
             file,
             description: descriptions[id] ?? prior?.description ?? id,
-            expected,
-            ...(manifestAnalyzeOptions(policy)
-                ? { analyzeOptions: manifestAnalyzeOptions(policy) }
-                : {}),
+            expected: {
+                games: result.gameCount,
+                moves: result.moveCount,
+            },
             ...(prior?.golden ? { golden: prior.golden } : {}),
         };
 
-        const skipped = expected.skippedGames ? `, ${expected.skippedGames} skipped` : '';
-        console.log(`${id}: ${result.gameCount} games, ${result.moveCount} moves${skipped}`);
+        console.log(`${id}: ${result.gameCount} games, ${result.moveCount} moves`);
     } catch (err) {
         if (prior) {
             fixtures[id] = { ...prior, file };

--- a/test/README.md
+++ b/test/README.md
@@ -41,11 +41,14 @@ Tests that run the full `analyzePGN` pipeline stay in `test/integration/` becaus
 
 | File                     | Focus                                                                |
 | ------------------------ | -------------------------------------------------------------------- |
-| `fixtures.test.ts`       | Small PGN fixtures, filters, tileTracker golden                      |
+| `fixtures.test.ts`       | Smoke matrix: every fixture × ST/MT expected game/move counts        |
+| `filters.test.ts`        | `filter` / `maxGames` / filter×workers rejection                     |
+| `multi-run.test.ts`      | Multi-run orchestration + volume via repeated fixtures               |
+| `trackers.test.ts`       | Tracker smokes + tileTracker golden (`en-passant`)                   |
 | `parse-pgn.test.ts`      | `chessalyzer/pgn` `parsePGN` / `streamParsePGN`, fixture move counts |
 | `workers.test.ts`        | MT `analyzePGN` abort / corrupt trailing game                        |
 | `custom-tracker.test.ts` | Custom tracker + `workerModule` in MT mode                           |
-| `error-policy.test.ts`   | `onError: 'abort'` / `'skip-game'`                                   |
+| `error-policy.test.ts`   | `onError: 'abort'` / `'skip-game'` (incl. `skippedGames`)            |
 | `exports.test.ts`        | `chessalyzer/board` subpath and `replay` option on `analyzePGN`      |
 | `corpus.test.ts`         | Optional large-file golden regression                                |
 
@@ -66,11 +69,11 @@ Corpus tests use `describe.skip` when `test/corpus/asorted-games.pgn` is missing
 | ------------------------------------ | --------------- | ------------- | -------------------------------------------- |
 | Public `parsePGN` / `streamParsePGN` | yes             | —             | `parse-pgn.test.ts`                          |
 | Basic parse counts                   | yes             | yes           | `fixtures.test.ts`, `corpus.test.ts`         |
-| Filter / maxGames                    | yes             | yes           | `fixtures.test.ts`, `corpus.test.ts`         |
-| Multi-run                            | —               | yes           | `fixtures.test.ts`                           |
+| Filter / maxGames                    | yes             | yes           | `filters.test.ts`, `corpus.test.ts`          |
+| Multi-run                            | yes             | yes           | `multi-run.test.ts`                          |
 | gameTracker golden                   | yes             | yes           | `corpus.test.ts` (corpus only)               |
 | pieceTracker golden                  | yes             | yes           | `corpus.test.ts` (corpus only)               |
-| tileTracker golden                   | yes             | yes           | `fixtures.test.ts` (`en-passant.pgn`)        |
+| tileTracker golden                   | yes             | yes           | `trackers.test.ts` (`en-passant.pgn`)        |
 | Custom tracker MT                    | —               | yes           | `custom-tracker.test.ts` (incl. filter path) |
 | Replay unit                          | yes             | —             | `src/replay/__tests__/game-replayer.test.ts` |
 | Error skip-game                      | yes             | yes           | `error-policy.test.ts`                       |

--- a/test/README.md
+++ b/test/README.md
@@ -92,7 +92,7 @@ bun run build && bun test    # full suite (CI: setup builds, then bun test)
 bun run test:build-fixtures  # merge-update manifest after fixture changes (preserves golden)
 ```
 
-`test:build-fixtures` re-analyzes each `test/fixtures/*.pgn` and updates `expected` counts. It preserves `golden` blocks and uses per-fixture `analyzeOptions` overrides (see `FIXTURE_ANALYZE` in `scripts/build-fixture-manifest.ts`) for error-policy fixtures like `bad-san-mid-file`.
+`test:build-fixtures` re-analyzes each `test/fixtures/*.pgn` (no trackers) and updates `expected` game/move counts. It preserves `golden` blocks and descriptions. Replay skip / `onError` behavior is covered in `error-policy.test.ts`, not the fixture manifest.
 
 CI (`.github/workflows/ci.yml`) runs `bun run build` then `bun test`. Corpus tests are included in `bun test` but skip when the local corpus file is absent.
 

--- a/test/fixtures/chessdotcom-headers.pgn
+++ b/test/fixtures/chessdotcom-headers.pgn
@@ -1,0 +1,373 @@
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Gholami, Aryan"]
+[Black "Panesar, Vedant"]
+[WhiteFideId "12513342"]
+[BlackFideId "35033018"]
+[Result "1-0"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:48:28"]
+[BlackClock "0:21:31"]
+
+
+1. Nf3  Nf6 2. b3  d5 3. Bb2  e6 4. e3  Be7 5. c4  O-O 6. Be2  c5 7. Nc3  Nc6 8. cxd5  Nxd5 9. Ne4  b6 10. Qc2  Ncb4 11. Qb1  Ba6 12. Bxa6  Nxa6 13. a3  h6 14. g4  Nf6 15. Rg1  Nxe4 16. Qxe4  Bf6 17. Bxf6  Qxf6 18. Ke2  g6 19. Qb7  e5 20. g5  hxg5 21. Qxa6  g4 22. Ne1  Qh4 23. Qc4  Qxh2 24. Rxg4  Qh5 25. Nf3  b5 26. Qe4  Rae8 27. Rh4 1-0
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Nguyen, Van Huy"]
+[Black "Gandhi, Anish"]
+[WhiteFideId "12401064"]
+[BlackFideId "5061032"]
+[Result "0-1"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:13:43"]
+[BlackClock "0:27:23"]
+
+
+1. d4  Nf6 2. c4  g6 3. Nc3  d5 4. cxd5  Nxd5 5. Bd2  Nb6 6. e4  Qxd4 7. Qc2  Nc6 8. Nf3  Qc5 9. Rc1  Bg7 10. Nb5  Qxc2 11. Rxc2  O-O 12. Nxc7  Rb8 13. Be3  Nb4 14. Rd2  Bg4 15. a3  Rbc8 16. Bf4  Nc6 17. Nb5  Na4 18. Rc2  Nxb2 19. Be2  Bxf3 20. gxf3  Na4 21. Bd1  a6 22. Nc7  Nc3 23. O-O  Nxd1 24. Rxd1  e5 25. Rd7  exf4 26. Nd5  Rb8 0-1
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Gupta, Abhijeet"]
+[Black "Saurabh, Anand"]
+[WhiteFideId "5010608"]
+[BlackFideId "5094496"]
+[Result "1/2-1/2"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "1:44:24"]
+[BlackClock "0:16:18"]
+
+
+1. d4  d5 2. c4  e6 3. Nc3  Be7 4. Nf3  Nf6 5. g3  O-O 6. Bg2  dxc4 7. Ne5  Nc6 8. Bxc6  bxc6 9. Nxc6  Qe8 10. Nxe7+  Qxe7 11. Qa4  c5 12. dxc5  Qxc5 13. Be3  Qc7 14. O-O-O  Bd7 15. Qa3  Bc6 16. f3  Nd5 17. Bd4  Rac8 18. Rd2  Nxc3 19. Bxc3  Qb8 20. Rhd1  Bb5 21. Rd4  e5 22. Rd6  f6 23. g4  a6 24. h4  Rfd8 25. Qb4  Rxd6 26. Rxd6  Qa7 27. a4  Be8 28. Rb6  Bxa4 29. Qd6  Qd7 30. Rxa6  Qxd6 31. Rxd6  Rc7 32. Ra6  Bb3 33. Kd2  Kf7 34. Ke3  h6 35. g5  hxg5 36. hxg5  Re7 37. Bb4  Re6 38. Ra7+  Kg6 39. gxf6  gxf6 40. Ke4  Rb6 41. Ba3  Bd1 42. Ke3  Bb3 43. Rd7  Kf5 44. Kf2  e4 45. Bc5  Rc6 46. Bd4  exf3 47. exf3  Ke6 48. Ra7  Rd6 49. Bc3  Rd3 50. Rc7  Rd7 51. Rc8  Rd6 52. Kg3  Kf5 53. Rc5+  Kg6 54. Kg4  Re6 55. Kf4  Rd6 56. Kg4  Re6 57. Rd5  Bc2 58. Kf4  Bb1 59. Rd4  Ba2 60. Kg4  Bb3 61. Rd2  Ba2 62. Rd5  Bb1 63. Rd4  Ba2 64. f4  f5+ 65. Kh4  Rc6 66. Rd7  Bb1 67. Kg3  Re6 68. Be5  Rb6 69. Kf2  Be4 70. Ke3  Rb7 71. Rd8  Kf7 72. Rc8  Bd3 73. Rc6  Ke7 74. Bc3  Rd7 75. Bf6+  Kf7 76. Bd4  Rd5 77. b3  Rb5 78. bxc4  Rb3 79. Kd2  Be4 80. Rc7+  Ke6 81. Bc3  Rb7 82. Rc8  Kd7 83. Rh8  Rc7 84. Rh7+  Kc8 85. Rh6  Rxc4 86. Be5  Kd7 87. Ke3  Ra4 88. Bc3  Rc4 89. Be5  Ra4 90. Rd6+  Ke7 91. Rb6  Rc4 92. Ra6  Kd7 93. Kf2  Rc2+ 94. Ke3  Rc4 1/2-1/2
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Bommini, Mounika Akshaya"]
+[Black "Rajesh, V A V"]
+[WhiteFideId "25019872"]
+[BlackFideId "5029317"]
+[Result "1/2-1/2"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:08:13"]
+[BlackClock "0:24:15"]
+
+
+1. d4  Nf6 2. c4  g6 3. Nc3  d5 4. cxd5  Nxd5 5. Bd2  Bg7 6. e4  Nb6 7. Be3  O-O 8. Be2  Nc6 9. Nf3  Bg4 10. e5  Nb4 11. Qd2  N6d5 12. Nxd5  Nxd5 13. Bh6  Qd7 14. Bxg7  Kxg7 15. h3  Bxf3 16. Bxf3  Rad8 17. h4  Qf5 18. O-O-O  c6 19. Rhe1  Rd7 20. h5  Rfd8 21. Re4  c5 22. h6+  Kg8 23. Rde1  Nb4 24. Bg4  Nxa2+ 25. Kb1  Rxd4 26. Qxd4  cxd4 27. Bxf5  gxf5 28. Rf4  Nb4 29. Rd1  Nc6 30. Rxf5  e6 31. Rg5+  Kf8 32. f4  Ne7 33. Rg3  Nf5 34. Rgd3  Ke7 35. R1d2  Rg8 36. Rb3  Rb8 37. Kc2  Rc8+ 38. Kd3  Rc7 39. Ke4  b6 40. Ra3  a5 41. Rb3  Rc6 42. g4  Nxh6 43. Kf3  Rc1 44. Rxd4  Rf1+ 45. Ke2  Rh1 46. g5  Nf5 47. Rc4  Rh2+ 48. Ke1  Kf8 49. Rxb6  Ne3 50. Re4  Nd5 51. Rb3  Kg7 52. Ra4  Kg6 53. Rxa5  Nxf4 54. Rf3  Kxg5 55. Rb5  Kg4 56. Ra3  Kf5 57. Rb7  Kxe5 1/2-1/2
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Sarbojit, Paul"]
+[Black "Anuj, Shrivatri"]
+[WhiteFideId "5094453"]
+[BlackFideId "35070924"]
+[Result "1/2-1/2"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:21:53"]
+[BlackClock "0:41:10"]
+
+
+1. e4  e5 2. Nf3  Nc6 3. Bb5  g6 4. O-O  Bg7 5. c3  a6 6. Ba4  b5 7. Bb3  d6 8. d4  exd4 9. cxd4  Nge7 10. Nc3  O-O 11. Nd5  h6 12. h3  Na5 13. Nxe7+  Qxe7 14. Bc2  c5 15. b3  Nc6 16. Be3  Qf6 17. e5  dxe5 18. dxe5  Nxe5 19. Be4  Rb8 20. Bxc5  Rd8 21. Qe2  Bxh3 22. Ba7  Nxf3+ 23. Qxf3  Qxf3 24. Bxf3  Bxa1 25. gxh3  Be5 26. Bxb8  Bxb8 27. Rd1  Rxd1+ 28. Bxd1  b4 29. Kf1  Kg7 30. Be2  a5 31. Bc4  f5 32. h4  Kf6 33. Kg2  Bd6 34. Kf3  Bc5 35. Kg3  Bd4 36. f4  Bc3 37. Be2  Be1+ 38. Kh3  Ke6 39. Bc4+  Ke7 40. Bg8  Bf2 41. Bc4  Bc5 42. Kg3  Be3 43. Bg8  Bd2 44. Bc4  Kf6 45. Bg8  Be1+ 46. Kh3  g5 47. hxg5+  hxg5 48. fxg5+  Kxg5 49. Kg2  Kf4 50. Kf1  Bh4 51. Ke2  Ke4 52. Bh7  Bg5 53. Bg6  Ke5 54. Kd3 1/2-1/2
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Ojas, Kulkarni"]
+[Black "Deepan, Chakkravarthy J."]
+[WhiteFideId "25040073"]
+[BlackFideId "5011132"]
+[Result "0-1"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:28:48"]
+[BlackClock "0:18:50"]
+
+
+1. d4  Nf6 2. c4  c5 3. d5  e6 4. Nc3  exd5 5. cxd5  d6 6. Nf3  g6 7. Bf4  Bg7 8. Qa4+  Bd7 9. Qb3  Qc7 10. e4  O-O 11. Be2  Na6 12. Nd2  Rfb8 13. Nc4  Ne8 14. e5  dxe5 15. d6  Nxd6 16. Nd5  Qd8 17. Nxd6  Be6 18. O-O-O  exf4 19. Bc4  Bd4 20. Nb5  Bxd5 21. Bxd5  Qf6 22. Kb1  Rd8 23. Nxd4  cxd4 24. Qxb7  Rab8 25. Bxf7+  Kf8 26. Qxa7  Ra8 0-1
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Harshavardhan, G B"]
+[Black "Pimpalkhare, Vedant"]
+[WhiteFideId "25059009"]
+[BlackFideId "25048236"]
+[Result "1-0"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:00:00"]
+[BlackClock "1:30:30"]
+
+
+1. d4  e6 2. c4  Nf6 3. Nc3  d5 4. Nf3  c5 5. cxd5  Nxd5 6. e4  Nxc3 7. bxc3  cxd4 8. cxd4  Bb4+ 9. Bd2  Bxd2+ 10. Qxd2  O-O 11. Bc4  Nd7 12. O-O  b6 13. e5  Bb7 14. Qe3  Bxf3 15. Qxf3  Qh4 16. Qe3  Rfd8 17. f4  Nf8 18. Rad1  Rac8 19. Bb3  g6 20. d5  exd5 21. Bxd5  Rc7 22. e6  fxe6 23. Bxe6+  Nxe6 24. Qxe6+  Kf8 25. g3 1-0
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Koustav, Chatterjee"]
+[Black "Patil, Pratik"]
+[WhiteFideId "25073060"]
+[BlackFideId "5038758"]
+[Result "1/2-1/2"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:44:25"]
+[BlackClock "0:39:50"]
+
+
+1. c4  Nf6 2. g3  c6 3. Nf3  g6 4. b3  Bg7 5. Bb2  O-O 6. Bg2  d5 7. O-O  Bf5 8. d3  Qc8 9. Re1  Bh3 10. Bh1  h6 11. Nbd2  Nbd7 12. Rc1  Qd8 13. cxd5  cxd5 14. e4  dxe4 15. dxe4  Rc8 16. Qe2  Nc5 17. Bd4  Ne6 18. Bxf6  Rxc1 19. Rxc1  Bxf6 20. Qe3  Bg7 21. Bg2  Bxg2 22. Kxg2  Qa5 23. Rc2  Rd8 24. Nc4  Qa6 25. h4  h5 26. Rd2  Rxd2 27. Qxd2  Qc6 28. Qd5  Qxd5 29. exd5  Nc7 30. d6  exd6 31. Nxd6  b5 32. Ng5  f6 33. Nh3  Bf8 34. Ne4  Nd5 35. a4  bxa4 36. bxa4  Kf7 37. Kf3  Kg8 38. Kg2  Kf7 39. Kf3  Kg8 40. Kg2  Kf7 41. Kf3 1/2-1/2
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Eraschenkov, Denis"]
+[Black "Safranska, Anda"]
+[WhiteFideId "4170733"]
+[BlackFideId "11600209"]
+[Result "1-0"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:32:09"]
+[BlackClock "0:25:51"]
+
+
+1. e4  g6 2. d4  Bg7 3. Nf3  a6 4. c4  d6 5. Nc3  e5 6. Bg5  f6 7. Be3  Nh6 8. h3  Nf7 9. Qd2  Nc6 10. O-O-O  O-O 11. Be2  Kh8 12. Kb1  Rb8 13. d5  Ne7 14. Ne1  f5 15. f3  c5 16. dxc6  bxc6 17. c5  dxc5 18. Qxd8  Rxd8 19. Rxd8+  Nxd8 20. Bg5  Rb7 21. Bxa6  Rd7 22. Bxc8  Nxc8 23. Bxd8  Rxd8 24. Nc2  Kg8 25. Ne3  f4 26. Nc4  Rd4 27. b3  Nd6 28. Nxd6  Rxd6 29. Kc2  Bf8 30. Na4  c4 31. bxc4  Rd4 32. Kc3  Bd6 33. Nb2  Kf7 34. Rd1  Ke6 35. Rxd4  exd4+ 36. Kb3  Kd7 37. Nd3  c5 38. Ka4  Kc6 39. Ka5  g5 40. Ka6  Bb8 41. a4  Bc7 42. e5  Bb8 43. e6  Bd6 44. h4  gxh4 45. Ka7  Kc7 46. a5  Kc6 47. a6  Kc7 48. Ka8  Kc8 49. a7  Kc7 50. Nxf4 1-0
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Aleksandrov, Aleksej"]
+[Black "Rakshitta, Ravi"]
+[WhiteFideId "13500139"]
+[BlackFideId "25073230"]
+[Result "1-0"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:58:26"]
+[BlackClock "0:01:34"]
+
+
+1. d4  Nf6 2. c4  Nc6 3. Nf3  e6 4. Nc3  Bb4 5. Qc2  Qe7 6. Bd2  d6 7. e4  Bxc3 8. Bxc3  e5 9. d5  Nb8 10. g3  a5 11. Nd2  O-O 12. Bg2  b6 13. O-O  Na6 14. a3  Ng4 15. h3  Nh6 16. f4  f5 17. Rae1  Nc5 18. b4  axb4 19. axb4  Nxe4 20. Nxe4  fxe4 21. fxe5  Rxf1+ 22. Rxf1  Nf5 23. e6  Qg5 24. Qf2  Qe3 25. Qxe3  Nxe3 26. Rf7  Nd1 27. Rxg7+  Kf8 28. Bf6  Bb7 29. Rxh7  Bc8 1-0
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Pranav, V"]
+[Black "Vaibhav, Suri"]
+[WhiteFideId "25060783"]
+[BlackFideId "5045185"]
+[Result "1/2-1/2"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:29:25"]
+[BlackClock "0:02:54"]
+
+
+1. e4  c5 2. Nf3  d6 3. d4  cxd4 4. Nxd4  Nf6 5. Nc3  a6 6. Be2  e5 7. Nb3  Be7 8. O-O  O-O 9. Kh1  Nc6 10. f4  Re8 11. f5  h6 12. Be3  b5 13. a4  b4 14. Nd5  Rb8 15. Qd3  Bb7 16. Bb6  Qc8 17. Nxf6+  Bxf6 18. Qxd6  Nd4 19. Bd3  Be7 20. Qc7  Qxc7 21. Bxc7  Rbc8 22. Nxd4  Rxc7 23. Nb3  Rd8 24. Na5  Ba8 25. b3  Rd4 26. Rae1  Bg5 27. Nc4  Rc5 28. g3  h5 29. Kg2  Bb7 30. h4  Bh6 31. Kf3  a5 32. Re2  Kf8 33. Kg2  Ke7 34. Kf3  Kf6 35. Rfe1  Rd8 36. Kg2  Rd4 37. Nb2  Rc7 38. Nd1  Ke7 39. Nf2  Rc3 40. Rh1  Bc6 41. g4  hxg4 42. Nxg4  Bf4 43. h5  Bxe4+ 44. Rxe4  Rxe4 45. Bxe4  Rg3+ 46. Kf2  Rxg4 47. Bf3  Rg5 48. h6  gxh6 49. Rxh6  Rxf5 50. Ra6  Bd2 51. Rxa5  Bc3 52. Ra7+  Kd6 53. Ra6+  Kc7 54. Rc6+  Kb8 55. Rc4  Rg5 56. Rg4  Bd4+ 1/2-1/2
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Manish, Kumar (2006)"]
+[Black "Shyaamnikhil, P"]
+[WhiteFideId "46605649"]
+[BlackFideId "5024218"]
+[Result "1/2-1/2"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:58:23"]
+[BlackClock "0:44:54"]
+
+
+1. e4  c5 2. Nf3  a6 3. c4  e6 4. Nc3  Qc7 5. a3  Nf6 6. d4  cxd4 7. Nxd4  b6 8. Be3  Bb7 9. f3  d6 10. Be2  Nbd7 11. Rc1  Rc8 12. O-O  Be7 13. Qd2  Qb8 14. b4  O-O 15. Rfd1  Rfe8 16. Nb3  Bf8 17. Bf4  Ne5 18. Bxe5  dxe5 19. Qe3  Bc6 20. c5  bxc5 21. Nxc5  Qb6 22. Qf2  a5 23. Rb1  Red8 24. Rxd8  Rxd8 25. Na6  Qd4 26. Rd1  Qxf2+ 27. Kxf2  Rxd1 28. Bxd1  Bb7 29. Nc5  Bxc5+ 30. bxc5  Nd7 31. Na4  f6 32. Nb6  Nxb6 33. cxb6  Kf7 34. Ke3  Ke7 35. Ba4  Kd6 36. Kd2  Kc5 37. Bd7  Kxb6 38. Bxe6  Kc5 39. Kc3  Ba6 40. g3  Be2 41. f4  Ba6 42. fxe5  fxe5 43. Bg8  h6 44. Bd5  Bc8 45. Ba8  Be6 46. Bb7  Kb5 47. Ba8  Ka4 48. Kb2  Kb5 49. Kc3  Kb6 50. Kd3  Kc5 51. Kc3  g5 52. Bb7  Kb6 53. Ba8  Kc5 54. Bb7  Kb6 55. Ba8  Kc5 56. Bb7  Kb6 57. Ba8 1/2-1/2
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Aakash Sharadchandra, Dalvi"]
+[Black "Sammed Jaykumar, Shete"]
+[WhiteFideId "25033220"]
+[BlackFideId "5073421"]
+[Result "0-1"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:30:14"]
+[BlackClock "0:40:55"]
+
+
+1. d4  Nf6 2. Bf4  g6 3. Nc3  d5 4. e3  Bg7 5. h4  h5 6. Nf3  O-O 7. Ne5  c5 8. Be2  Nc6 9. Qd2  Bf5 10. f3  cxd4 11. exd4  Qb6 12. Nxc6  Qxc6 13. O-O-O  Rfc8 14. Bb5  Qb6 15. Bd3  Bxd3 16. Qxd3  Rc4 17. b3  Rc6 18. Na4  Qa5 19. Kb1  Nd7 20. Bd2  Qc7 21. g4  Nf6 22. Bg5  hxg4 23. Bxf6  Rxf6 24. fxg4  Rf4 25. Qg3  Rc8 26. c3  Bxd4 27. Rc1  Be5 28. Qd3  Qd7 29. h5  Qxg4 30. hxg6  Qf5 31. gxf7+  Kxf7 32. Rh7+  Ke6 33. Qxf5+  Rxf5 34. Re1  Kd6 35. b4  b6 36. Re3  Rf2 37. Rh5  Bf6 38. Rd3  d4 39. Rh1  Rc4 40. a3  Kc6 41. cxd4  Bxd4 42. Rc1  Rxc1+ 43. Kxc1  Kd5 0-1
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Nikhil, Magizhnan"]
+[Black "Ameir, Moheb"]
+[WhiteFideId "35075497"]
+[BlackFideId "10600620"]
+[Result "0-1"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:00:00"]
+[BlackClock "1:30:30"]
+
+
+1. e4  c6 2. d4  d5 3. e5  Bf5 4. Ne2  e6 5. Ng3  Bg6 6. h4  h5 7. c4  Ne7 8. Nc3  dxc4 9. Bxc4  Nf5 10. Nge2  Bh7 11. Bg5  Be7 12. Qd2  Nd7 13. Ne4  Nb6 14. Bd3  f6 15. exf6  gxf6 16. Be3  Nd5 17. O-O  Nxh4 18. N4g3  Bxd3 19. Qxd3  Qd7 20. Rad1  O-O-O 21. Rfe1  Rdg8 22. Bc1  Bd6 23. Nc3  Nxg2 24. Kxg2  Nxc3 25. bxc3  h4 26. Rh1  hxg3 27. Rxh8  Rxh8 28. fxg3  Rg8 29. Rh1  Rxg3+ 30. Qxg3  Bxg3 31. Kxg3  e5 32. Be3  b6 33. Rh6  Kb7 34. Kf2  Qf5+ 35. Ke1  Qd3 36. Bd2 0-1
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Stupak, Kirill"]
+[Black "Lokesh, N."]
+[WhiteFideId "13503758"]
+[BlackFideId "5025044"]
+[Result "1-0"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:02:59"]
+[BlackClock "0:01:16"]
+
+
+1. d4  Nf6 2. c4  e6 3. Nc3  d5 4. cxd5  exd5 5. Bg5  Be7 6. e3  O-O 7. Bd3  Nbd7 8. Qc2  b6 9. Nf3  Bb7 10. Bf4  c5 11. O-O  g6 12. Rfd1  Rc8 13. Be2  Ne4 14. dxc5  Rxc5 15. Nd4  Bh4 16. Rf1  Re8 17. Qa4  Nxc3 18. bxc3  a6 19. Qb4  Be7 20. Qb2  Bf8 21. a4  Bc8 22. Rab1  Qf6 23. Rfd1  h5 24. h3  Bg7 25. Bf3  Ra5 26. Bc7  Rxa4 27. Bxd5  b5 28. c4  Nb6 29. Bxb6  Qxb6 30. cxb5  Bxd4 31. Qb3  Bxe3 32. Bxf7+  Kf8 33. Bxe8  Bxf2+ 34. Kh1  Rf4 35. Bd7  Bb7 36. Bc6  axb5 37. Bxb7  Qxb7 38. Qe6  Qe4 39. Rd8+  Kg7 40. Qg8+  Kh6 41. Rbd1  Bb6 42. Re8  Qc4 43. Qh8+  Kg5 44. Qe5+  Kh4 45. Qe7+  g5 46. g3+  Kxg3 47. Qxg5+  Kxh3 48. Qxh5+  Kg3 49. Qh2+  Kg4 50. Qg2+  Kf5 51. Rd5+ 1-0
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Kulkarni, Vinayak"]
+[Black "Rahman, Ziaur"]
+[WhiteFideId "5021332"]
+[BlackFideId "10200037"]
+[Result "1/2-1/2"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:21:33"]
+[BlackClock "0:43:52"]
+
+
+1. d4  b6 2. e4  Bb7 3. Bd3  g6 4. Nf3  Bg7 5. O-O  d6 6. a4  a6 7. a5  b5 8. c4  c6 9. Bd2  Nd7 10. Re1  e5 11. cxb5  axb5 12. d5  Nc5 13. Bf1  Nf6 14. Bg5  Qd7 15. Bxf6  Bxf6 16. Nc3  O-O 17. b4  Na6 18. Qb3  Nc7 19. dxc6  Bxc6 20. Red1  Bg7 21. Rd2  Rfe8 22. Rad1  Bf8 23. Ne1  Ne6 24. Nc2  Qb7 25. Nd5  Red8 26. Nce3  Nd4 27. Qc3  Rac8 28. Qa3  Bh6 29. Ng4  Bxd2 30. Ngf6+  Kg7 31. Rxd2  Bxd5 32. Nxd5  Re8 33. Qe3  Qa7 34. Nb6  Rcd8 35. Rxd4  exd4 36. Qxd4+  f6 37. Bxb5  Re5 38. Bc4  d5 39. f3  Rh5 40. exd5  Qe7 41. Bf1  Qa7 42. Bc4  Qe7 43. Bf1  Qa7 1/2-1/2
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Rios, Cristhian Camilo"]
+[Black "Subhayan, Kundu"]
+[WhiteFideId "4403940"]
+[BlackFideId "5094801"]
+[Result "1/2-1/2"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:39:07"]
+[BlackClock "0:00:46"]
+
+
+1. d4  f5 2. c4  Nf6 3. Nc3  d6 4. Bg5  Nbd7 5. Qc2  g6 6. Nh3  e5 7. dxe5  dxe5 8. O-O-O  c6 9. e4  h6 10. Bxf6  Qxf6 11. f4  Nc5 12. Bd3  Be7 13. Rhe1  O-O 14. fxe5  Qh4 15. exf5  Nxd3+ 16. Qxd3  Bxf5 17. Qd4  Rad8 18. Qxh4  Bxh4 19. Rf1  Bxh3 20. gxh3  Rxf1 21. Rxf1  Re8 22. Ne4  Rxe5 23. Nd6  b5 24. Rf3  Be7 25. Nf7  Rh5 26. b3  Kg7 27. Kd2  bxc4 28. bxc4  Ra5 29. a4  Rxa4 30. Ne5  Bf6 31. Nxc6  a6 32. c5  Rc4 33. Nb8  Rxc5 34. Nxa6  Rc4 35. Kd3  Rc3+ 36. Ke2  Rc2+ 37. Kd3  Rxh2 38. Nc7  Ra2 39. Ne8+  Kf7 40. Rxf6+  Kxe8 1/2-1/2
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Jeet, Jain"]
+[Black "Yakubboev, Nodirbek"]
+[WhiteFideId "5073022"]
+[BlackFideId "14203987"]
+[Result "0-1"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:02:22"]
+[BlackClock "0:11:57"]
+
+
+1. e4  Nf6 2. Nc3  e5 3. Nf3  Nc6 4. d4  exd4 5. Nxd4  Bb4 6. Nxc6  bxc6 7. Bd3  d6 8. Bg5  h6 9. Bh4  Be6 10. O-O  g5 11. Bg3  h5 12. f3  h4 13. Bf2  Bxc3 14. bxc3  Nd7 15. Ba6  c5 16. Bb5  Kf8 17. Bxd7  Qxd7 18. h3  Rb8 19. Qd2  Rg8 20. Kh2  Qc6 21. Rfb1  Rxb1 22. Rxb1  Ke7 23. Qc1  Qa4 24. a3  f6 25. Rb7  Kd7 26. Rb1  Ba2 27. Ra1  Bc4 28. Rb1  Ra8 29. Qb2  Qc6 30. Qb7  Qxb7 31. Rxb7  Kc6 32. Rb1  Re8 33. Re1  Rb8 34. f4  Rb2 35. fxg5  fxg5 36. Be3  g4 37. hxg4  Rxc2 38. Kh3  Rxc3 39. Kxh4  Rxa3 40. Bf4  Ra2 41. g3  a5 42. e5  a4 43. g5  Rh2+ 44. Kg4  Be6+ 45. Kf3  a3 46. exd6  Bd5+ 47. Ke3  cxd6 48. g6  Rh1 49. Rxh1  Bxh1 50. Bg5  a2 51. Bf6  d5 52. Ba1  d4+ 53. Kd3  Bd5 54. g4  Be6 55. g7  Kd5 56. Kc2  Ke4 57. g5  c4 58. Kd2  c3+ 59. Kc2 0-1
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Puranik, Abhimanyu"]
+[Black "Luong, Phuong Hanh"]
+[WhiteFideId "5061245"]
+[BlackFideId "12401013"]
+[Result "1-0"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:11:06"]
+[BlackClock "1:07:17"]
+
+
+1. Nf3  Nf6 2. g3  g6 3. b3  Bg7 4. Bb2  d6 5. d4  O-O 6. Bg2  Nc6 7. O-O  e5 8. dxe5  Nd7 9. c4  Ndxe5 10. Nxe5  dxe5 11. Nc3  Be6 12. Nd5  Qd7 13. Qd2  Rfd8 14. Qg5  Bxd5 15. cxd5  Nd4 16. Qd2  Qg4 17. f3  Qf5 18. e3  Qc2 19. Rf2  Qxd2 20. Rxd2  Nf5 21. e4  Nd4 22. Rc1  c6 23. f4  cxd5 24. fxe5  Nc6 25. exd5  Nxe5 26. Rc7  Bh6 27. Re2  Nd3 28. Bf6  Re8 29. Rxe8+  Rxe8 30. d6  Be3+ 31. Kf1  Bc5 32. Re7  Rd8 33. Re2  Rf8 34. d7  Bb6 35. Re8 1-0
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Das, Sayantan"]
+[Black "Thanki, Hemal Karsanji"]
+[WhiteFideId "5034426"]
+[BlackFideId "5024927"]
+[Result "1-0"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:31:26"]
+[BlackClock "0:19:29"]
+
+
+1. e4  c5 2. Nf3  Nc6 3. Bb5  g6 4. O-O  Bg7 5. c3  Nf6 6. Re1  O-O 7. d4  d5 8. e5  Ne4 9. Nbd2  cxd4 10. cxd4  Nxd2 11. Bxd2  Qb6 12. Bxc6  Qxc6 13. h3  Bf5 14. Bb4  Rfe8 15. Rc1  Qb5 16. Qd2  Rac8 17. Nh4  Qd7 18. a4  h5 19. Qg5  e6 20. Rxc8  Qxc8 21. a5  Be4 22. f3  Bd3 23. Qe3  Ba6 24. Rc1  Qd7 25. g4  hxg4 26. fxg4  Rc8 27. Rxc8+  Qxc8 28. Qc3  Qd7 29. Nf3  b6 30. axb6  axb6 31. Kf2  Qb5 32. Kg3  Bh6 33. Be7  Qf1 34. Qc6  Bb5 35. Qc8+  Kh7 36. Bf6  Bg7 37. Ng5+  Kh6 38. Nxf7+  Kh7 39. Ng5+  Kh6 40. Bxg7+  Kxg7 41. Nxe6+  Kf7 42. Ng5+  Kg7 43. Qc7+  Kg8 44. Qh7+  Kf8 45. Qh8+  Ke7 46. Qg7+  Ke8 47. Qxg6+  Ke7 48. Qe6+  Kd8 49. Qf6+ 1-0
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Bharat, Kumar Reddy Poluri"]
+[Black "Bakshi, Rutuja"]
+[WhiteFideId "46600353"]
+[BlackFideId "5016509"]
+[Result "1-0"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:19:36"]
+[BlackClock "0:05:12"]
+
+
+1. e4  e6 2. d4  d5 3. Nd2  c5 4. Ngf3  Nc6 5. exd5  exd5 6. Bb5  Bd6 7. O-O  Ne7 8. dxc5  Bxc5 9. Nb3  Bd6 10. Re1  O-O 11. h3  Bf5 12. c3  h6 13. Be3  Qc7 14. Nfd4  Be4 15. Bd3  Bxd3 16. Qxd3  Ne5 17. Qc2  Qd7 18. Rad1  Nc4 19. Nf3  Rad8 20. Bc5  Qc7 21. Bxd6  Nxd6 22. Rd3  Ne4 23. Nfd2  Nc6 24. Rde3  f5 25. Nf3  Qb6 26. Rd1  Rf6 27. Red3  Rfd6 28. Nbd4  g6 29. a3  Na5 30. a4  a6 31. b4  Nc4 32. a5  Qa7 33. Nb3  b6 34. Ra1  bxa5 35. Nxa5  Qb6 36. Nd4  Ne5 37. Re3  Nc4 38. Nxc4  dxc4 39. Rxe4  fxe4 40. Qxe4  Rf6 41. Ra5  Qd6 42. Re5  Rdf8 43. f3  Qd7 44. Re7  Qa4 45. Qd5+  R8f7 46. Qxc4  Qd1+ 47. Kh2  Qd2 48. Re4  Kh7 49. Qc8  Rf4 50. Re8  Rxd4 51. cxd4  Qf4+ 52. Kh1  Qxd4 53. Qb8  Rd7 54. Re6  a5 55. b5  a4 56. Ra6  Qf2 57. Kh2  Qd4 58. b6  h5 59. b7  Qc4 60. Ra8 1-0
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Parnali, S Dharia"]
+[Black "Czebe, Attila"]
+[WhiteFideId "5043131"]
+[BlackFideId "705268"]
+[Result "0-1"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:16:55"]
+[BlackClock "1:08:57"]
+
+
+1. d4  Nf6 2. c4  b6 3. Nc3  Bb7 4. f3  d5 5. cxd5  Nxd5 6. e4  Nxc3 7. bxc3  e5 8. Qa4+  Qd7 9. Qxd7+  Nxd7 10. Be3  Ba3 11. Rb1  O-O-O 12. Bc4  Rhf8 13. Ne2  f5 14. exf5  e4 15. fxe4  Bxe4 16. Rb3  Bd6 17. O-O  Bxf5 18. Bf4  Be4 19. Rb5  Rde8 20. Rg5  g6 21. Rg3  Bb7 22. Bxd6  Rxf1+ 23. Kxf1  cxd6 24. Ke1  Nf6 25. Bd3  Kd7 26. h4  Be4 27. Bb5+  Bc6 28. Bd3  Re7 29. a3  Be4 30. Kd2  Nh5 31. Rg5  Nf6 32. Rg3  Nh5 33. Rg5  Bxd3 34. Kxd3  Rf7 35. g4  Ng7 36. h5  Rf6 37. d5  Ke7 38. Ke3  Rf1 39. Ng3  Rg1 40. Kf2  Rxg3 41. Kxg3  Kf7 42. c4  Ne8 43. Kf4  Nf6 44. Ke3  Ng8 45. Kf4  Kf6 46. Rxg6+  hxg6 47. g5+  Kg7 48. h6+  Nxh6 49. gxh6+  Kxh6 50. Kg4  Kg7 51. Kg5  Kf7 52. Kg4  Kf6 53. Kf4  g5+ 0-1
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Navalgund, Niranjan"]
+[Black "Debashis, Das"]
+[WhiteFideId "5030854"]
+[BlackFideId "5024854"]
+[Result "1-0"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:06:25"]
+[BlackClock "0:21:39"]
+
+
+1. d4  e6 2. c4  b6 3. e4  Bb7 4. Bd3  Nc6 5. Nf3  Nb4 6. Nc3  Nxd3+ 7. Qxd3  d6 8. Bg5  Qd7 9. O-O  Ne7 10. Nd2  h6 11. Be3  g6 12. d5  Bg7 13. f4  O-O 14. dxe6  fxe6 15. Bd4  e5 16. Bxe5  Nc6 17. Bxg7  Qxg7 18. Nd5  Rf7 19. b3  Raf8 20. Rae1  a5 21. a3  Kh8 22. Re3  Nd4 23. g3  Bc8 24. Nf3  Nc6 25. Qc3  Kh7 26. Qxg7+  Kxg7 27. Kg2  Re8 28. h3  Bb7 29. Rfe1  Bc8 30. g4  Bb7 31. Kg3  Bc8 32. h4  Ba6 33. e5  Re6 34. exd6  Rxd6 35. Ne5  Nxe5 36. fxe5  Re6 37. Nf4  Rc6 38. e6  Re7 39. Nd5  Re8 40. Rf3 1-0
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Manik, Mikulas"]
+[Black "Kamdar, Udit"]
+[WhiteFideId "14900734"]
+[BlackFideId "35046284"]
+[Result "1-0"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "1:06:33"]
+[BlackClock "0:00:44"]
+
+
+1. e4  c6 2. Nf3  d5 3. Nc3  Bg4 4. h3  Bxf3 5. Qxf3  Nf6 6. d3  e6 7. Bd2  Nbd7 8. g3  Be7 9. Bg2  O-O 10. O-O  b5 11. Qe2  b4 12. Nd1  Qc7 13. f4  Rfd8 14. Nf2  Nf8 15. e5  N6d7 16. d4  c5 17. dxc5  Bxc5 18. Kh2  Be7 19. c4  bxc3 20. Bxc3  Nb6 21. Bd4  Rac8 22. Nd3  Qc2 23. Qf3  Qa4 24. Qe3  Nfd7 25. f5  Bf8 26. fxe6  fxe6 27. Nf4  Re8 28. b3  Qb4 29. a3  Qb5 30. a4  Qa5 31. Nh5  Be7 32. Nf6+  Bxf6 33. exf6  Nxf6 34. Rxf6  gxf6 35. Bxf6  d4 36. Qh6  Rc7 37. Rf1  Rf7 38. Rf4  Rxf6 39. Qxf6  Qh5 40. Rg4+ 1-0
+
+
+[Event "2019-eka-iifl-wealth-gm-open"]
+[White "Souhardo, Basak"]
+[Black "Bogdanovich, Stanislav"]
+[WhiteFideId "35092910"]
+[BlackFideId "14115298"]
+[Result "0-1"]
+[Round "01"]
+[Date "Wed Jan 01 2020"]
+[WhiteClock "0:16:50"]
+[BlackClock "0:54:09"]
+
+
+1. e4  c5 2. Nf3  Nc6 3. d4  cxd4 4. Nxd4  g6 5. Be3  Nf6 6. Nc3  Bg7 7. Be2  O-O 8. O-O  d5 9. Nxc6  bxc6 10. e5  Ne8 11. f4  f6 12. Bd4  fxe5 13. fxe5  Rxf1+ 14. Bxf1  Nc7 15. Na4  Ne6 16. Qd2  Nxd4 17. Qxd4  Rb8 18. b4  Qd6 19. c3  Bxe5 20. Qxa7  Bxh2+ 21. Kh1  g5 22. Be2  Qh6 23. Bf3  g4 24. Bd1  Bg3+ 25. Kg1  Qh2+ 26. Kf1  Ba6+ 27. Qxa6  Qh1+ 28. Ke2  Qe1+ 29. Kd3  Qe4+ 30. Kd2  Bf4# 0-1

--- a/test/fixtures/manifest.json
+++ b/test/fixtures/manifest.json
@@ -3,12 +3,13 @@
     "fixtures": {
         "bad-san-mid-file": {
             "file": "bad-san-mid-file.pgn",
-            "description": "Three games; middle game has illegal SAN (error-policy tests use a move tracker to force replay)",
+            "description": "Three games; middle game has illegal SAN (error-policy tests)",
             "expected": {
                 "games": 3,
                 "moves": 33
             },
             "analyzeOptions": {
+                "workers": false,
                 "onError": "skip-game"
             }
         },
@@ -26,6 +27,14 @@
             "expected": {
                 "games": 1,
                 "moves": 4
+            }
+        },
+        "chessdotcom-headers": {
+            "file": "chessdotcom-headers.pgn",
+            "description": "Exported from Chess.com (2020)",
+            "expected": {
+                "games": 25,
+                "moves": 2228
             }
         },
         "comments-multiline": {

--- a/test/fixtures/manifest.json
+++ b/test/fixtures/manifest.json
@@ -7,10 +7,6 @@
             "expected": {
                 "games": 3,
                 "moves": 33
-            },
-            "analyzeOptions": {
-                "workers": false,
-                "onError": "skip-game"
             }
         },
         "basic-normal": {
@@ -55,7 +51,7 @@
         },
         "corrupt": {
             "file": "corrupt.pgn",
-            "description": "One complete game plus one truncated game at EOF (incomplete game dropped at parse; not counted in skippedGames)",
+            "description": "One complete game plus one truncated game at EOF (incomplete trailing game dropped at parse)",
             "expected": {
                 "games": 1,
                 "moves": 15

--- a/test/fixtures/manifest.json
+++ b/test/fixtures/manifest.json
@@ -55,7 +55,7 @@
         },
         "corrupt": {
             "file": "corrupt.pgn",
-            "description": "One complete game plus one truncated game at EOF",
+            "description": "One complete game plus one truncated game at EOF (incomplete game dropped at parse; not counted in skippedGames)",
             "expected": {
                 "games": 1,
                 "moves": 15

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -27,7 +27,7 @@ export interface FixtureEntry {
     file: string;
     description: string;
     expected: { games: number; moves: number; skippedGames?: number };
-    analyzeOptions?: { onError?: 'abort' | 'skip-game' };
+    analyzeOptions?: { onError?: 'abort' | 'skip-game'; workers?: false };
     golden?: {
         tileTracker?: TileTrackerGolden;
     };

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -48,8 +48,7 @@ export function fixtureExpected(id: FixtureId) {
 export function getFixtureEntry(id: FixtureId): FixtureEntry {
     const entry = manifest.fixtures[id];
     if (!entry) throw new Error(`Unknown fixture id: ${id}`);
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- JSON manifest shape matches FixtureEntry; keys are validated via FixtureId
-    return entry as FixtureEntry;
+    return entry;
 }
 
 /**

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -26,8 +26,7 @@ interface TileTrackerGolden {
 export interface FixtureEntry {
     file: string;
     description: string;
-    expected: { games: number; moves: number; skippedGames?: number };
-    analyzeOptions?: { onError?: 'abort' | 'skip-game'; workers?: false };
+    expected: { games: number; moves: number };
     golden?: {
         tileTracker?: TileTrackerGolden;
     };

--- a/test/integration/exports.type-test.ts
+++ b/test/integration/exports.type-test.ts
@@ -19,6 +19,7 @@ import type {
     HeatmapPieceRef,
     TrackerInstance,
 } from 'chessalyzer/trackers';
+import { gameTracker } from 'chessalyzer/trackers';
 
 type ReplayOption = NonNullable<AnalyzeOptions['replay']>;
 const replayBoard: ReplayOption = 'board';
@@ -40,7 +41,7 @@ const runResult: AnalyzeRunResult = { gameCount: 0, moveCount: 0 };
 const workerOpts: WorkerOptions = { count: 4 };
 const run: AnalyzeRun = { trackers: [] };
 const filter: GameFilter = () => true;
-const instance: TrackerInstance = { def: {} as never, state: {} };
+const instance: TrackerInstance = gameTracker();
 
 // @ts-expect-error HeatmapData is not exported from the root entry
 type RootHeatmapData = import('chessalyzer').HeatmapData;

--- a/test/integration/filters.test.ts
+++ b/test/integration/filters.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'bun:test';
+
+import { analyzePGN } from 'chessalyzer';
+import type { ParsedGame } from 'chessalyzer/pgn';
+
+import { fixturePath } from '~/test/helpers/fixtures';
+
+describe('Filtering', () => {
+    it('limits by maxGames (single-threaded)', async () => {
+        const data = await analyzePGN(fixturePath('results-mix'), {
+            maxGames: 3,
+            workers: false,
+        });
+        expect(data.gameCount).toBe(3);
+    });
+
+    it('limits by maxGames (multithreaded)', async () => {
+        const data = await analyzePGN(fixturePath('results-mix'), {
+            maxGames: 3,
+        });
+        expect(data.gameCount).toBe(3);
+    });
+
+    it('filters by result (single-threaded)', async () => {
+        const data = await analyzePGN(fixturePath('results-mix'), {
+            filter: (game: ParsedGame) => game.result === '1-0',
+        });
+        expect(data.gameCount).toBe(3);
+    });
+
+    it('rejects filter with an explicit worker pool', () => {
+        const options = {
+            filter: (game: ParsedGame) => game.result === '1-0',
+            workers: 2,
+        };
+
+        // @ts-expect-error - test case
+        expect(analyzePGN(fixturePath('results-mix'), options)).rejects.toThrow(
+            'filter cannot be used with worker threads',
+        );
+    });
+
+    it('combines filter and count (single-threaded)', async () => {
+        const data = await analyzePGN(fixturePath('results-mix'), {
+            maxGames: 2,
+            filter: (game: ParsedGame) => game.result === '0-1',
+        });
+        expect(data.gameCount).toBe(2);
+    });
+});

--- a/test/integration/fixtures.test.ts
+++ b/test/integration/fixtures.test.ts
@@ -1,222 +1,48 @@
-import { describe, it, beforeAll, afterAll, expect } from 'bun:test';
+import { describe, it, beforeAll, expect } from 'bun:test';
 
 import { analyzePGN } from 'chessalyzer';
 import type { AnalyzeResult } from 'chessalyzer';
-import type { ParsedGame } from 'chessalyzer/pgn';
-import {
-    gameTracker,
-    generateHeatmap,
-    pieceTracker,
-    TileHeatmapPresets,
-    tileTracker,
-} from 'chessalyzer/trackers';
 
-import {
-    allFixtureIds,
-    cleanupTmpPgns,
-    fixtureExpected,
-    fixturePath,
-    getFixtureEntry,
-    repeatPgn,
-} from '~/test/helpers/fixtures';
+import { allFixtureIds, fixturePath, getFixtureEntry } from '~/test/helpers/fixtures';
 
-// Integration tests against small committed PGN fixtures (test/fixtures/).
+/**
+ * Smoke matrix: every committed fixture parses/analyzes to the expected counts
+ * in both single-threaded and multithreaded mode.
+ *
+ * Behavior coverage (filters, multi-run, tracker goldens) lives in sibling files.
+ */
 describe('Fixtures', () => {
-    afterAll(async () => {
-        await cleanupTmpPgns();
-    });
-
     for (const id of allFixtureIds) {
         describe(id, () => {
-            let data: AnalyzeResult;
+            for (const [mode, workers] of [
+                ['single-threaded', false],
+                ['multithreaded', undefined],
+            ] as const) {
+                describe(mode, () => {
+                    let data: AnalyzeResult;
 
-            beforeAll(async () => {
-                const entry = getFixtureEntry(id);
-                data = await analyzePGN(fixturePath(id), {
-                    workers: false,
-                    ...entry.analyzeOptions,
+                    beforeAll(async () => {
+                        const entry = getFixtureEntry(id);
+                        const { workers: _fixtureWorkers, ...fixtureOpts } =
+                            entry.analyzeOptions ?? {};
+                        data = await analyzePGN(fixturePath(id), {
+                            ...fixtureOpts,
+                            ...(workers === false ? { workers: false } : {}),
+                        });
+                    });
+
+                    it('parses the expected number of games and moves', () => {
+                        const expected = getFixtureEntry(id).expected;
+                        expect(data.gameCount).toBe(expected.games);
+                        expect(data.moveCount).toBe(expected.moves);
+                        if (expected.skippedGames !== undefined) {
+                            expect(data.skippedGames).toBe(expected.skippedGames);
+                        } else {
+                            expect(data.skippedGames).toBeUndefined();
+                        }
+                    });
                 });
-            });
-
-            it('parses the expected number of games and moves', () => {
-                const expected = getFixtureEntry(id).expected;
-                expect(data.gameCount).toBe(expected.games);
-                expect(data.moveCount).toBe(expected.moves);
-                if (expected.skippedGames !== undefined) {
-                    expect(data.skippedGames).toBe(expected.skippedGames);
-                }
-            });
+            }
         });
     }
-
-    describe('corrupt fixture', () => {
-        it('drops the incomplete trailing game', async () => {
-            const data = await analyzePGN(fixturePath('corrupt'), { workers: false });
-            expect(data.gameCount).toBe(1);
-        });
-    });
-
-    describe('results-mix filtering', () => {
-        it('limits by maxGames (single-threaded)', async () => {
-            const data = await analyzePGN(fixturePath('results-mix'), {
-                maxGames: 3,
-                workers: false,
-            });
-            expect(data.gameCount).toBe(3);
-        });
-
-        it('limits by maxGames (multithreaded)', async () => {
-            const data = await analyzePGN(fixturePath('results-mix'), {
-                maxGames: 3,
-            });
-            expect(data.gameCount).toBe(3);
-        });
-
-        it('filters by result (single-threaded)', async () => {
-            const data = await analyzePGN(fixturePath('results-mix'), {
-                filter: (game: ParsedGame) => game.result === '1-0',
-            });
-            expect(data.gameCount).toBe(3);
-        });
-
-        it('rejects filter with an explicit worker pool', () => {
-            const options = {
-                filter: (game: ParsedGame) => game.result === '1-0',
-                workers: 2,
-            };
-
-            // @ts-expect-error - test case
-            expect(analyzePGN(fixturePath('results-mix'), options)).rejects.toThrow(
-                'filter cannot be used with worker threads',
-            );
-        });
-
-        it('combines filter and count (single-threaded)', async () => {
-            const data = await analyzePGN(fixturePath('results-mix'), {
-                maxGames: 2,
-                filter: (game: ParsedGame) => game.result === '0-1',
-            });
-            expect(data.gameCount).toBe(2);
-        });
-    });
-
-    describe('volume via repeated fixtures', () => {
-        it('processes many games from a repeated small fixture', async () => {
-            const path = await repeatPgn('results-mix', 20);
-            const data = await analyzePGN(path, { workers: false });
-            expect(data.gameCount).toBe(fixtureExpected('results-mix').games * 20);
-        });
-
-        it('keeps tracker counts consistent at scale', async () => {
-            const path = await repeatPgn('results-mix', 50);
-            const games = gameTracker();
-            const data = await analyzePGN(path, { trackers: [games], workers: false });
-            expect(data.gameCount).toBe(games.state.gameCount);
-            const resultsSum = Object.values(games.state.results).reduce((a, c) => a + c, 0);
-            expect(resultsSum).toBe(data.gameCount);
-        });
-    });
-
-    describe('worker-parse multi-run', () => {
-        it('processes all runs without sharing detached chunk buffers', async () => {
-            const expected = fixtureExpected('results-mix');
-            const a = gameTracker();
-            const b = gameTracker();
-
-            const data = await analyzePGN(fixturePath('results-mix'), {
-                runs: [{ trackers: [a] }, { trackers: [b] }],
-            });
-
-            expect(data.runs[0]?.gameCount).toBe(expected.games);
-            expect(data.runs[1]?.gameCount).toBe(expected.games);
-            expect(a.state.gameCount).toBe(expected.games);
-            expect(b.state.gameCount).toBe(expected.games);
-        });
-
-        it('handles mixed filter and unfiltered runs in one pass', async () => {
-            const all = gameTracker();
-            const whiteWins = gameTracker();
-            const data = await analyzePGN(fixturePath('results-mix'), {
-                workers: false,
-                runs: [
-                    { trackers: [all] },
-                    {
-                        trackers: [whiteWins],
-                        filter: (game: ParsedGame) => game.result === '1-0',
-                    },
-                ],
-            });
-
-            expect(data.runs[0]?.gameCount).toBe(fixtureExpected('results-mix').games);
-            expect(data.runs[1]?.gameCount).toBe(3);
-            expect(all.state.gameCount).toBe(fixtureExpected('results-mix').games);
-            expect(whiteWins.state.gameCount).toBe(3);
-        });
-
-        it('respects per-run maxGames in multi-run', async () => {
-            const capped = gameTracker();
-            const full = gameTracker();
-            const data = await analyzePGN(fixturePath('results-mix'), {
-                runs: [{ trackers: [capped], maxGames: 2 }, { trackers: [full] }],
-            });
-
-            expect(data.runs[0]?.gameCount).toBe(2);
-            expect(data.runs[1]?.gameCount).toBe(fixtureExpected('results-mix').games);
-            expect(capped.state.gameCount).toBe(2);
-            expect(full.state.gameCount).toBe(fixtureExpected('results-mix').games);
-        });
-    });
-
-    describe('trackers on fixtures', () => {
-        it('runs GameTracker on lichess-headers', async () => {
-            const games = gameTracker();
-            const data = await analyzePGN(fixturePath('lichess-headers'), {
-                trackers: [games],
-            });
-            expect(data.gameCount).toBe(1);
-            expect(games.state.gameCount).toBe(1);
-        });
-
-        it('runs PieceTracker on promotion', async () => {
-            const data = await analyzePGN(fixturePath('promotion'), {
-                trackers: [pieceTracker()],
-            });
-            expect(data.gameCount).toBe(1);
-            expect(data.moveCount).toBeGreaterThan(0);
-        });
-    });
-
-    describe('TileTracker golden (en-passant)', () => {
-        const golden = getFixtureEntry('en-passant').golden?.tileTracker;
-        if (!golden) throw new Error('en-passant fixture missing TileTracker golden values');
-
-        for (const [mode, workers] of [
-            ['single-threaded', false],
-            ['multithreaded', undefined],
-        ] as const) {
-            it(`matches golden values (${mode})`, async () => {
-                const tiles = tileTracker();
-                const data = await analyzePGN(fixturePath('en-passant'), {
-                    trackers: [tiles],
-                    ...(workers === false ? { workers: false } : {}),
-                });
-
-                expect(data.gameCount).toBe(1);
-                expect(tiles.state.movesTotal).toBe(golden.movesTotal);
-                const heat = generateHeatmap(tiles.state, TileHeatmapPresets.TILE_OCC_ALL);
-                expect(heat.map[4]?.[4]).toBe(golden.e4TileOccAll);
-            });
-        }
-
-        it('counts castling as one move (rook leg excluded from move counter)', async () => {
-            const tiles = tileTracker();
-            await analyzePGN(fixturePath('en-passant'), {
-                trackers: [tiles],
-                workers: false,
-            });
-
-            expect(tiles.state.movesTotal).toBe(golden.movesTotal);
-            expect(tiles.state.movesTotal).toBe(fixtureExpected('en-passant').moves);
-        });
-    });
 });

--- a/test/integration/fixtures.test.ts
+++ b/test/integration/fixtures.test.ts
@@ -22,11 +22,7 @@ describe('Fixtures', () => {
                     let data: AnalyzeResult;
 
                     beforeAll(async () => {
-                        const entry = getFixtureEntry(id);
-                        const { workers: _fixtureWorkers, ...fixtureOpts } =
-                            entry.analyzeOptions ?? {};
                         data = await analyzePGN(fixturePath(id), {
-                            ...fixtureOpts,
                             ...(workers === false ? { workers: false } : {}),
                         });
                     });
@@ -35,11 +31,6 @@ describe('Fixtures', () => {
                         const expected = getFixtureEntry(id).expected;
                         expect(data.gameCount).toBe(expected.games);
                         expect(data.moveCount).toBe(expected.moves);
-                        if (expected.skippedGames !== undefined) {
-                            expect(data.skippedGames).toBe(expected.skippedGames);
-                        } else {
-                            expect(data.skippedGames).toBeUndefined();
-                        }
                     });
                 });
             }

--- a/test/integration/fixtures.test.ts
+++ b/test/integration/fixtures.test.ts
@@ -22,9 +22,10 @@ describe('Fixtures', () => {
                     let data: AnalyzeResult;
 
                     beforeAll(async () => {
-                        data = await analyzePGN(fixturePath(id), {
-                            ...(workers === false ? { workers: false } : {}),
-                        });
+                        data = await analyzePGN(
+                            fixturePath(id),
+                            workers === false ? { workers: false } : undefined,
+                        );
                     });
 
                     it('parses the expected number of games and moves', () => {

--- a/test/integration/multi-run.test.ts
+++ b/test/integration/multi-run.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, afterAll, expect } from 'bun:test';
+
+import { analyzePGN } from 'chessalyzer';
+import type { ParsedGame } from 'chessalyzer/pgn';
+import { gameTracker } from 'chessalyzer/trackers';
+
+import { cleanupTmpPgns, fixtureExpected, fixturePath, repeatPgn } from '~/test/helpers/fixtures';
+
+describe('Multi-run', () => {
+    it('processes all runs without sharing detached chunk buffers', async () => {
+        const expected = fixtureExpected('results-mix');
+        const a = gameTracker();
+        const b = gameTracker();
+
+        const data = await analyzePGN(fixturePath('results-mix'), {
+            runs: [{ trackers: [a] }, { trackers: [b] }],
+        });
+
+        expect(data.runs[0]?.gameCount).toBe(expected.games);
+        expect(data.runs[1]?.gameCount).toBe(expected.games);
+        expect(a.state.gameCount).toBe(expected.games);
+        expect(b.state.gameCount).toBe(expected.games);
+    });
+
+    it('handles mixed filter and unfiltered runs in one pass', async () => {
+        const all = gameTracker();
+        const whiteWins = gameTracker();
+        const data = await analyzePGN(fixturePath('results-mix'), {
+            workers: false,
+            runs: [
+                { trackers: [all] },
+                {
+                    trackers: [whiteWins],
+                    filter: (game: ParsedGame) => game.result === '1-0',
+                },
+            ],
+        });
+
+        expect(data.runs[0]?.gameCount).toBe(fixtureExpected('results-mix').games);
+        expect(data.runs[1]?.gameCount).toBe(3);
+        expect(all.state.gameCount).toBe(fixtureExpected('results-mix').games);
+        expect(whiteWins.state.gameCount).toBe(3);
+    });
+
+    it('respects per-run maxGames in multi-run', async () => {
+        const capped = gameTracker();
+        const full = gameTracker();
+        const data = await analyzePGN(fixturePath('results-mix'), {
+            runs: [{ trackers: [capped], maxGames: 2 }, { trackers: [full] }],
+        });
+
+        expect(data.runs[0]?.gameCount).toBe(2);
+        expect(data.runs[1]?.gameCount).toBe(fixtureExpected('results-mix').games);
+        expect(capped.state.gameCount).toBe(2);
+        expect(full.state.gameCount).toBe(fixtureExpected('results-mix').games);
+    });
+});
+
+describe('Volume via repeated fixtures', () => {
+    afterAll(async () => {
+        await cleanupTmpPgns();
+    });
+
+    it('processes many games from a repeated small fixture', async () => {
+        const path = await repeatPgn('results-mix', 20);
+        const data = await analyzePGN(path, { workers: false });
+        expect(data.gameCount).toBe(fixtureExpected('results-mix').games * 20);
+    });
+
+    it('keeps tracker counts consistent at scale', async () => {
+        const path = await repeatPgn('results-mix', 50);
+        const games = gameTracker();
+        const data = await analyzePGN(path, { trackers: [games], workers: false });
+        expect(data.gameCount).toBe(games.state.gameCount);
+        const resultsSum = Object.values(games.state.results).reduce((a, c) => a + c, 0);
+        expect(resultsSum).toBe(data.gameCount);
+    });
+});

--- a/test/integration/trackers.test.ts
+++ b/test/integration/trackers.test.ts
@@ -40,10 +40,10 @@ describe('TileTracker golden (en-passant)', () => {
     ] as const) {
         it(`matches golden values (${mode})`, async () => {
             const tiles = tileTracker();
-            const data = await analyzePGN(fixturePath('en-passant'), {
-                trackers: [tiles],
-                ...(workers === false ? { workers: false } : {}),
-            });
+            const data = await analyzePGN(
+                fixturePath('en-passant'),
+                workers === false ? { trackers: [tiles], workers: false } : { trackers: [tiles] },
+            );
 
             expect(data.gameCount).toBe(1);
             expect(tiles.state.movesTotal).toBe(golden.movesTotal);

--- a/test/integration/trackers.test.ts
+++ b/test/integration/trackers.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'bun:test';
+
+import { analyzePGN } from 'chessalyzer';
+import {
+    gameTracker,
+    generateHeatmap,
+    pieceTracker,
+    TileHeatmapPresets,
+    tileTracker,
+} from 'chessalyzer/trackers';
+
+import { fixtureExpected, fixturePath, getFixtureEntry } from '~/test/helpers/fixtures';
+
+describe('Trackers on fixtures', () => {
+    it('runs GameTracker on lichess-headers', async () => {
+        const games = gameTracker();
+        const data = await analyzePGN(fixturePath('lichess-headers'), {
+            trackers: [games],
+        });
+        expect(data.gameCount).toBe(1);
+        expect(games.state.gameCount).toBe(1);
+    });
+
+    it('runs PieceTracker on promotion', async () => {
+        const data = await analyzePGN(fixturePath('promotion'), {
+            trackers: [pieceTracker()],
+        });
+        expect(data.gameCount).toBe(1);
+        expect(data.moveCount).toBeGreaterThan(0);
+    });
+});
+
+describe('TileTracker golden (en-passant)', () => {
+    const golden = getFixtureEntry('en-passant').golden?.tileTracker;
+    if (!golden) throw new Error('en-passant fixture missing TileTracker golden values');
+
+    for (const [mode, workers] of [
+        ['single-threaded', false],
+        ['multithreaded', undefined],
+    ] as const) {
+        it(`matches golden values (${mode})`, async () => {
+            const tiles = tileTracker();
+            const data = await analyzePGN(fixturePath('en-passant'), {
+                trackers: [tiles],
+                ...(workers === false ? { workers: false } : {}),
+            });
+
+            expect(data.gameCount).toBe(1);
+            expect(tiles.state.movesTotal).toBe(golden.movesTotal);
+            const heat = generateHeatmap(tiles.state, TileHeatmapPresets.TILE_OCC_ALL);
+            expect(heat.map[4]?.[4]).toBe(golden.e4TileOccAll);
+        });
+    }
+
+    it('counts castling as one move (rook leg excluded from move counter)', async () => {
+        const tiles = tileTracker();
+        await analyzePGN(fixturePath('en-passant'), {
+            trackers: [tiles],
+            workers: false,
+        });
+
+        expect(tiles.state.movesTotal).toBe(golden.movesTotal);
+        expect(tiles.state.movesTotal).toBe(fixtureExpected('en-passant').moves);
+    });
+});


### PR DESCRIPTION
- Moves non smoke-test tests out of fixtures.test.ts into dedicated files
- Run each smoke fixture in ST and MT mode
- Add chess.com fixture file