### PR TITLE
fix(errors): throw typed ReplayError from workers instead of generic Error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Chessalyzer.js parses large PGN databases and runs user-defined **trackers** ove
 | `test/`              | Integration tests, fixtures, corpus (unit tests live in `src/**/__tests__/`)                                                |
 | `pgn/`               | Local large PGN files for manual/bench runs (gitignored)                                                                    |
 | `manual-tests/`      | Release smoke tests against the built package                                                                               |
+| `docs/`              | Fumadocs site (`content/docs/` MDX, `examples/` sample PGN + output generator). Style: [`docs/STYLE.md`](docs/STYLE.md)     |
 
 **Runtime:** Node ≥ 22 or Bun. Tests and benches are typically run with Bun.
 
@@ -181,6 +182,10 @@ Pass `single-threaded` to `bench-perf` to benchmark only the single-threaded pat
 - `manual-tests/test-release-singlethreaded.ts` — single-threaded (`workers: false`)
 
 Place large Lichess exports in `pgn/` (gitignored). The perf bench automatically picks the largest file available.
+
+### Documentation
+
+User-facing docs live in [`docs/content/docs/`](docs/content/docs/) (Fumadocs / Waku). When editing or adding pages, follow **[`docs/STYLE.md`](docs/STYLE.md)** — friendly, example-first Guides; internals in Going Further; real return shapes from [`docs/examples/`](docs/examples/); Callouts for tips and caveats; no changelog leftovers.
 
 ### Tests
 

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1,0 +1,91 @@
+# Documentation style
+
+This guide is for anyone (human or agent) writing or editing Chessalyzer docs under [`docs/content/docs/`](content/docs/). Match the voice and structure of the existing pages — especially [Welcome](content/docs/index.mdx), [Your first analysis](content/docs/quickstart.mdx), and [Filtering games](content/docs/filters.mdx).
+
+The site is Fumadocs on Waku. Content lives as MDX; navigation is [`content/docs/meta.json`](content/docs/meta.json) (and nested `meta.json` files for Trackers / Heatmaps).
+
+## Audience and tone
+
+Docs should feel **friendly, warm, and approachable** — including for readers who are not deeply technical. Prefer teaching over reference dumps.
+
+- **Second person** ("you"), contractions, short sentences.
+- Lead with **what the reader wants to do**, not with internals.
+- Prefer plain-language headings ("Your first analysis", "Filtering games") over API names when the page is a guide.
+- Tables are for true reference material (options, fields, presets). Prefer short prose + one good example over long field inventories.
+- Avoid sounding like a changelog, a migration guide, or a PR description.
+
+## Information architecture
+
+Three sections in the sidebar:
+
+| Section             | Purpose                                                               |
+| ------------------- | --------------------------------------------------------------------- |
+| **Getting started** | Install, first win, orientation                                       |
+| **Guides**          | Everyday use: trackers, heatmaps, parsing, filters, comparing, errors |
+| **Going further**   | Internals, pipeline deep dives, multithreading, performance rationale |
+
+Put pipeline stages, worker merge semantics, and optimization notes in **Going further**. If a technical detail matters on a Guide page (e.g. why a filter forces single-threaded mode), use a **Callout** and link to the deep dive — do not expand the guide into a systems essay.
+
+## Concrete examples and return shapes
+
+Never leave the reader guessing what comes back from a call.
+
+1. Prefer the shared example file [`examples/games.pgn`](examples/games.pgn) (three short games, mixed ELOs). Show it inline on the quickstart; elsewhere link to `/docs/quickstart#the-example-file`.
+2. Use `'games.pgn'` in code samples — not `'<pathToPgnFile>'` or abstract placeholders.
+3. For every public function you introduce, show **real return shapes**: `AnalyzeResult`, `ParsedGame[]`, tracker `.state`, `HeatmapData`, error entries, etc.
+4. Prefer **annotated excerpts** when full JSON is huge (e.g. trim `byPiece` zeros, keep the squares that tell the story). Say when something is trimmed.
+5. When an output is machine-sensitive (`durationMs`, `movesPerSecond`), note that the reader's numbers will differ.
+
+### Regenerating outputs
+
+[`examples/generate-outputs.ts`](examples/generate-outputs.ts) runs the library against `games.pgn` and prints the values used in the docs. When the API or the sample file changes:
+
+```bash
+bun docs/examples/generate-outputs.ts
+```
+
+Paste fresh outputs into the MDX pages. Do not invent plausible JSON by hand.
+
+## Callouts
+
+Fumadocs `<Callout>` is available in MDX. Use it for asides that would break the narrative flow:
+
+| `type` | Use for                                                                              |
+| ------ | ------------------------------------------------------------------------------------ |
+| `idea` | Tips and follow-ups (e.g. `heatmapToString`, when to stream-parse)                   |
+| `info` | Technical asides that matter on this page (e.g. filters → single-threaded)           |
+| `warn` | Pitfalls (reading state mid-analysis, recycled `Action` objects, no legality checks) |
+
+Give every callout a short, memorable `title`. Keep the body to a few sentences; link to Going Further for the long version.
+
+```mdx
+<Callout type="info" title="Why filters run single-threaded">
+    A filter is a JavaScript closure, and closures can't be shipped to worker threads…
+</Callout>
+```
+
+## What not to write
+
+- **Changelog / migration leftovers** — do not mention removed options, previous APIs, or "no special X field is required anymore." Describe the current API only.
+- **Placeholder paths and fake shapes** — do not invent return JSON; regenerate it.
+- **Internal jargon in Guides** without a callout or link — `AssembledGame`, worker snapshots, chunk byte targets belong in Going Further (or a titled Callout).
+- **Dense option tables as the whole page** — open with a story and a working snippet first.
+- **First-person or corporate marketing voice** — no "we are excited to announce," no "leverage," no "robust solution."
+
+## Page shape (checklist)
+
+A good Guide page usually has:
+
+1. One-sentence promise of what the reader will learn.
+2. A working code snippet using `games.pgn` (or a clear link to it).
+3. The **real** result / state / shape, with a one-line reading of what it means.
+4. Callouts for caveats and tips.
+5. Cross-links to the next natural page (and to Going Further only when the reader opts in).
+
+A good Going Further page may be denser, use tables and diagrams, and assume Guides are already read.
+
+## Tooling notes
+
+- `docs/examples/` is excluded from the docs TypeScript/`oxlint` configs (it imports the library from source). Keep it that way.
+- Small example PGNs under `docs/examples/` are tracked via a `!.gitignore` exception (`*.pgn` is ignored globally).
+- After content changes: `cd docs && bun run typecheck && bun run lint && bun run build`.

--- a/docs/content/docs/error-handling.mdx
+++ b/docs/content/docs/error-handling.mdx
@@ -36,14 +36,6 @@ try {
 
 `isReplayError` narrows the thrown value so you can read `gameIndex` (which game, zero-based), `moveIndex` (which half-move), `san`, and a machine-readable `reason`.
 
-<Callout type="info" title="Threading changes what you catch">
-    The typed error above is what you get single-threaded. With the default worker pool, a broken
-    game still aborts the run and rejects the promise — but the error crossing the thread boundary
-    arrives as a plain `Error` with the same message, without the structured fields. If you rely on
-    `isReplayError` data, prefer collecting errors with `onError: 'skip-game'` (below), where they
-    arrive fully typed on the result object in both modes.
-</Callout>
-
 ## Skip bad games and keep going
 
 For batch runs over mostly-good data (think Lichess database dumps), aborting on one bad apple wastes the whole run. `onError: 'skip-game'` collects the failures and finishes the rest:

--- a/docs/content/docs/how-it-works.mdx
+++ b/docs/content/docs/how-it-works.mdx
@@ -14,11 +14,9 @@ Every PGN file flows through the same four stages:
 ```
 
 1. **I/O** — the file is streamed from disk, never loaded whole. In multithreaded mode it's cut into byte-sized chunks aligned to game boundaries; single-threaded it's read line by line.
-
-1. **I/O** — the file is streamed from disk, never loaded whole. In multithreaded mode it's cut into byte-sized chunks aligned to game boundaries; single-threaded it's read line by line.
-1. **PGN parse** — each game is split into tag-pair headers, mainline move strings (SAN), and the result. This stage is purely textual: no board, no legality, just structure.
-1. **Replay** — each SAN string is decoded and played on an internal board. This is the expensive part, and it's what move trackers need: they care _where_ pieces stand, not just _what_ was played.
-1. **Analyze** — your trackers run over the results and accumulate state.
+2. **PGN parse** — each game is split into tag-pair headers, mainline move strings (SAN), and the result. This stage is purely textual: no board, no legality, just structure.
+3. **Replay** — each SAN string is decoded and played on an internal board. This is the expensive part, and it's what move trackers need: they care _where_ pieces stand, not just _what_ was played.
+4. **Analyze** — your trackers run over the results and accumulate state.
 
 A subtlety worth knowing: when people say "PGN parser" they usually mean stage 2. Turning a file into _moves on a board_ takes stages 2 + 3, which is why the [parser module](/docs/parsing-pgn) and `analyzePGN` are separate tools.
 

--- a/docs/content/docs/multithreading.mdx
+++ b/docs/content/docs/multithreading.mdx
@@ -60,5 +60,3 @@ Two situations call for it — or force it:
 
 - **Filters.** A [`filter`](/docs/filters) is a JavaScript closure, and closures can't cross the worker boundary, so filtered analyses are single-threaded automatically. Passing explicit `workers` options together with a filter is rejected as an error.
 - **Custom tracker development.** [Custom trackers](/docs/trackers/custom) need their module setup (`id`, `workerModule: import.meta.url`, `merge`) before they can join the pool; while sketching one out, `workers: false` keeps things simple and debuggable. The `workerModule` URL also requires an unbundled Node ≥ 22 or Bun runtime.
-
-One honest caveat for the other direction: in multithreaded mode, a fatal replay error aborts the run as a plain `Error` (only the message survives the thread boundary). If you need typed `isReplayError` data, use [`onError: 'skip-game'`](/docs/error-handling), which delivers fully typed errors on the result in both modes.

--- a/docs/examples/generate-outputs.ts
+++ b/docs/examples/generate-outputs.ts
@@ -171,7 +171,8 @@ try {
     print('ERROR_RESULT', json(errorResult));
 
     try {
-        await analyzePGN(TMP_BAD_PGN, { trackers: [tileTracker()], workers: false });
+        // default worker pool — typed ReplayError must survive the thread boundary
+        await analyzePGN(TMP_BAD_PGN, { trackers: [tileTracker()] });
     } catch (err) {
         print('ABORT_THROWN', json(err, Object.getOwnPropertyNames(err as object)));
         print('ABORT_IS_REPLAY_ERROR', String(isReplayError(err)));

--- a/src/core/__tests__/analyze-errors.test.ts
+++ b/src/core/__tests__/analyze-errors.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'bun:test';
 
 import {
     createReplayError,
+    errorFromWorkerBatchFailure,
     getAnalyzeError,
     isReplayError,
     toAbortError,
+    toWorkerBatchError,
 } from '#core/analyze-errors';
 
 describe('analyze-errors', () => {
@@ -38,5 +40,41 @@ describe('analyze-errors', () => {
         if (isReplayError(unwrapped)) {
             expect(unwrapped.gameIndex).toBe(2);
         }
+    });
+
+    it('toWorkerBatchError strips cause and keeps replay fields', () => {
+        const thrown = toAbortError({ ...replayError, cause: new Error('inner') });
+        const payload = toWorkerBatchError(thrown);
+        expect(isReplayError(payload)).toBe(true);
+        if (isReplayError(payload)) {
+            expect(payload.gameIndex).toBe(2);
+            expect(payload.moveIndex).toBe(5);
+            expect(payload.san).toBe('Qh5');
+            expect(payload.reason).toBe('IllegalMove');
+            expect(payload.message).toBe('illegal move');
+            expect(payload.cause).toBeUndefined();
+        }
+    });
+
+    it('toWorkerBatchError falls back to a message string', () => {
+        expect(toWorkerBatchError(new Error('boom'))).toBe('boom');
+        expect(toWorkerBatchError('plain')).toBe('plain');
+    });
+
+    it('errorFromWorkerBatchFailure rebuilds AnalyzeAbortError from a structured payload', () => {
+        const rebuilt = errorFromWorkerBatchFailure(replayError);
+        expect(rebuilt.name).toBe('AnalyzeAbortError');
+        expect(isReplayError(rebuilt)).toBe(true);
+        if (isReplayError(rebuilt)) {
+            expect(rebuilt.gameIndex).toBe(2);
+            expect(rebuilt.san).toBe('Qh5');
+        }
+    });
+
+    it('errorFromWorkerBatchFailure keeps plain string failures as Error', () => {
+        const rebuilt = errorFromWorkerBatchFailure('Unknown tracker "x"');
+        expect(rebuilt).toBeInstanceOf(Error);
+        expect(rebuilt.message).toBe('Unknown tracker "x"');
+        expect(isReplayError(rebuilt)).toBe(false);
     });
 });

--- a/src/core/__tests__/fixtures/stub-structured-error-worker.ts
+++ b/src/core/__tests__/fixtures/stub-structured-error-worker.ts
@@ -1,0 +1,23 @@
+/**
+ * Stub worker that posts a structured replay AnalyzeError via `result.error`.
+ * Used to assert WorkerPool rebuilds a typed abort error on the main thread.
+ */
+import assert from 'node:assert';
+import { parentPort } from 'node:worker_threads';
+
+assert(parentPort, 'stub-structured-error-worker must run as a worker thread');
+const port = parentPort;
+
+port.on('message', () => {
+    port.postMessage({
+        results: [],
+        error: {
+            code: 'replay',
+            gameIndex: 3,
+            moveIndex: 2,
+            san: 'Nf9',
+            reason: 'IllegalMove',
+            message: 'w: No piece for move N to (7,6) found!',
+        },
+    });
+});

--- a/src/core/__tests__/worker-pool.test.ts
+++ b/src/core/__tests__/worker-pool.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from 'bun:test';
 import { fileURLToPath } from 'node:url';
 
+import { isReplayError } from '#core/analyze-errors';
 import WorkerPool from '#core/worker-pool';
 import type { WorkerMessage } from '#core/worker-types';
 
@@ -108,6 +109,31 @@ describe('WorkerPool', () => {
         expect(err).toBeInstanceOf(Error);
         expect(err?.message).toContain('Unknown tracker');
         expect(result).toBeNull();
+        expect(pool.failed).toBe(true);
+    });
+
+    it('rejects runTask with typed ReplayError when worker posts a structured error', async () => {
+        const structuredErrorWorkerPath = fileURLToPath(
+            new URL('fixtures/stub-structured-error-worker.ts', import.meta.url),
+        );
+        pool = new WorkerPool(1, structuredErrorWorkerPath, emptyInit);
+
+        const { err } = await runTaskWithTimeout(
+            pool,
+            {
+                type: 'batch',
+                pgnChunkBytes: minimalChunkBytes(),
+                configs: [{ idxConfig: 0, parseHeaders: false }],
+            },
+            10_000,
+        );
+
+        expect(isReplayError(err)).toBe(true);
+        if (isReplayError(err)) {
+            expect(err.gameIndex).toBe(3);
+            expect(err.san).toBe('Nf9');
+            expect(err.reason).toBe('IllegalMove');
+        }
         expect(pool.failed).toBe(true);
     });
 });

--- a/src/core/analyze-errors.ts
+++ b/src/core/analyze-errors.ts
@@ -51,6 +51,32 @@ export function isReplayError(err: unknown): err is ReplayError {
     return err.code === 'replay' && typeof err.gameIndex === 'number';
 }
 
+/**
+ * Plain cloneable payload for worker → main abort reporting.
+ * Omits `cause` so structured clone never has to ferry Error instances.
+ */
+export function toWorkerBatchError(err: unknown): string | AnalyzeError {
+    if (isReplayError(err)) {
+        const payload: ReplayError = {
+            code: err.code,
+            gameIndex: err.gameIndex,
+            moveIndex: err.moveIndex,
+            san: err.san,
+            reason: err.reason,
+            message: err.message,
+        };
+        return payload;
+    }
+    return err instanceof Error ? err.message : String(err);
+}
+
+/** Rebuild a thrown error from a worker batch `error` field (string or structured). */
+export function errorFromWorkerBatchFailure(error: string | AnalyzeError): Error {
+    if (typeof error === 'string') return new Error(error);
+    if (isReplayError(error)) return toAbortError(error);
+    return new Error(error.message);
+}
+
 /** Thrown in abort mode; replay fields are copied onto the error for {@link isReplayError}. */
 export function toAbortError(replayError: ReplayError): Error {
     const err = new Error(replayError.message);

--- a/src/core/chess-worker.ts
+++ b/src/core/chess-worker.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { parentPort, workerData } from 'node:worker_threads';
 
+import { toWorkerBatchError } from '#core/analyze-errors';
 import {
     getCachedCfg,
     initWorkerTrackers,
@@ -134,10 +135,10 @@ port.on('message', (msg: WorkerTaskData) => {
         .catch((e: unknown) => {
             // Return errors to the main thread instead of throwing — unhandled worker
             // rejections would otherwise leave the pool waiting indefinitely.
-            const message = e instanceof Error ? e.message : String(e);
+            // Replay aborts keep structured fields so `isReplayError` works on the main thread.
             const errorResult: WorkerMessage = {
                 results: [],
-                error: message,
+                error: toWorkerBatchError(e),
             };
             // oxlint-disable-next-line unicorn/require-post-message-target-origin -- Node worker_threads MessagePort has no targetOrigin
             port.postMessage(errorResult);

--- a/src/core/tracker-merge.ts
+++ b/src/core/tracker-merge.ts
@@ -1,6 +1,6 @@
 import type { GameAndMoveCount } from '#core/analysis-runtime';
 import type { GameProcessorConfig } from '#core/analysis-runtime';
-import { collectError } from '#core/analyze-errors';
+import { collectError, errorFromWorkerBatchFailure } from '#core/analyze-errors';
 import type { WorkerBatchConfigResult, WorkerMessage } from '#core/worker-types';
 
 /**
@@ -34,7 +34,7 @@ export function mergeWorkerTrackerFlush(
     configs: GameProcessorConfig[],
     result: WorkerMessage,
 ): void {
-    if (result.error) throw new Error(result.error);
+    if (result.error) throw errorFromWorkerBatchFailure(result.error);
 
     for (const configResult of result.results) {
         if (!('trackerSnapshots' in configResult)) continue;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -1,5 +1,6 @@
 import { Worker } from 'node:worker_threads';
 
+import { errorFromWorkerBatchFailure } from '#core/analyze-errors';
 import type {
     WorkerBatchTask,
     WorkerInitData,
@@ -160,7 +161,7 @@ export default class WorkerPool {
 
             // Workers report batch failures via result.error instead of throwing.
             if (result.error) {
-                const err = new Error(result.error);
+                const err = errorFromWorkerBatchFailure(result.error);
                 task?.reject(err);
                 this.fail(err);
             } else {

--- a/src/core/worker-types.ts
+++ b/src/core/worker-types.ts
@@ -60,6 +60,9 @@ export type WorkerConfigResult = WorkerBatchConfigResult | WorkerFlushConfigResu
 /** Worker → main result: one or more config results, or a batch-level error. */
 export interface WorkerMessage {
     results: WorkerConfigResult[];
-    /** Set when batch processing failed catastrophically; main thread should abort. */
-    error?: string;
+    /**
+     * Set when batch processing failed catastrophically; main thread should abort.
+     * Replay aborts are a structured {@link AnalyzeError}; other failures stay plain strings.
+     */
+    error?: string | AnalyzeError;
 }

--- a/test/integration/error-policy.test.ts
+++ b/test/integration/error-policy.test.ts
@@ -27,6 +27,24 @@ describe('Error policy', () => {
         expect(isReplayError(analyzeError)).toBe(true);
     });
 
+    it('aborts with typed ReplayError in multithreaded mode', async () => {
+        let caught: unknown;
+        try {
+            await analyzePGN(badSanPath, { trackers: [pieceTracker()] });
+        } catch (err) {
+            caught = err;
+        }
+
+        expect(caught).toBeDefined();
+        expect(isReplayError(caught)).toBe(true);
+        if (isReplayError(caught)) {
+            expect(caught.gameIndex).toBe(1);
+            expect(caught.moveIndex).toBe(0);
+            expect(caught.san).toBe('Nf9');
+            expect(caught.reason).toBe('IllegalMove');
+        }
+    });
+
     it('skip-game continues with error summary (single-threaded)', async () => {
         const data = await analyzePGN(badSanPath, {
             workers: false,


### PR DESCRIPTION
Workers where only passing the Error message to the worker pool. Now returns all data needed to create a ReplayError for better debugging and consistency.