### PR TITLE
refactor: move perf stats to dedicated perf key in the analyzePGN return type

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["oxc.oxc-vscode", "bradlc.vscode-tailwindcss"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Chessalyzer.js parses large PGN databases and runs user-defined **trackers** ove
 | `manual-tests/`      | Release smoke tests against the built package                                                                               |
 | `docs/`              | Fumadocs site (`content/docs/` MDX, `examples/` sample PGN + output generator). Style: [`docs/STYLE.md`](docs/STYLE.md)     |
 
-**Runtime:** Node ≥ 22 or Bun. Tests and benches are typically run with Bun.
+**Runtime:** Any JavaScript runtime, Node.js ≥ 22 or Bun recommended. Tests and benches are typically run with Bun.
 
 ### Type organization
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`AnalyzeResult` shape (breaking):** `durationMs` and `movesPerSecond` are now nested under a dedicated `perf: AnalyzePerformance` sub-object (`result.perf.durationMs`, `result.perf.movesPerSecond`).
+
 ## [4.0.0-beta.1] - 2026-08-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Requires any JavaScript runtime, Node.js ≥ 22 or Bun recommended.
 
 ## Getting started
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import {
     tileTracker,

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Guides for installation, basic usage, the analysis pipeline, built-in and custom
 npm install chessalyzer
 ```
 
-Requires Node ≥ 22 or Bun.
+Requires any JavaScript runtime, Node.js ≥ 22 or Bun recommended.
 
 ## Getting started
 

--- a/bench/exploratory/profile-bottlenecks-node.ts
+++ b/bench/exploratory/profile-bottlenecks-node.ts
@@ -81,7 +81,7 @@ async function api(options: AnalyzeOptions) {
         ms,
         cntGames: result.gameCount,
         cntMoves: result.moveCount,
-        mps: result.movesPerSecond,
+        mps: result.perf.movesPerSecond,
     };
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "chessalyzer",
       "devDependencies": {
         "@types/bun": "^1.3.14",
-        "@types/node": "^26.1.2",
+        "@types/node": "^26.2.0",
         "bumpp": "^12.2.0",
         "bun-plugin-dts": "^0.4.0",
         "knip": "^6.32.0",
@@ -14,28 +14,28 @@
         "oxlint": "^1.77.0",
         "oxlint-tsgolint": "^7.0.2001",
         "tinybench": "^6.1.2",
-        "tsx": "^4.23.9",
+        "tsx": "^4.23.11",
         "typescript": "6.0.3",
       },
     },
     "docs": {
       "name": "chessalyzer-docs",
       "dependencies": {
-        "fumadocs-core": "16.14.1",
+        "fumadocs-core": "16.14.2",
         "fumadocs-mdx": "15.2.2",
-        "fumadocs-ui": "npm:@fumadocs/base-ui@16.14.1",
-        "lucide-react": "^1.29.0",
+        "fumadocs-ui": "npm:@fumadocs/base-ui@16.14.2",
+        "lucide-react": "^1.30.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-server-dom-webpack": "^19.2.8",
-        "takumi-js": "^2.5.10",
+        "takumi-js": "^2.5.11",
         "use-sync-external-store": "^1.6.0",
-        "waku": "1.0.0-beta.8",
+        "waku": "1.0.0-beta.9",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.3",
         "@types/mdx": "^2.0.14",
-        "@types/node": "^26.1.2",
+        "@types/node": "^26.2.0",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "tailwindcss": "^4.3.3",
@@ -45,7 +45,7 @@
     },
   },
   "overrides": {
-    "@types/node": "^26.1.2",
+    "@types/node": "^26.2.0",
   },
   "packages": {
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
@@ -392,27 +392,27 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
 
-    "@takumi-rs/core": ["@takumi-rs/core@2.5.10", "", { "dependencies": { "@takumi-rs/helpers": "2.5.10" }, "optionalDependencies": { "@takumi-rs/core-darwin-arm64": "2.5.10", "@takumi-rs/core-darwin-x64": "2.5.10", "@takumi-rs/core-linux-arm64-gnu": "2.5.10", "@takumi-rs/core-linux-arm64-musl": "2.5.10", "@takumi-rs/core-linux-x64-gnu": "2.5.10", "@takumi-rs/core-linux-x64-musl": "2.5.10", "@takumi-rs/core-win32-arm64-msvc": "2.5.10", "@takumi-rs/core-win32-x64-msvc": "2.5.10" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-aFm4nldCGXWMqfz6Kw+JZ79GkJuB8nKsP4uHseSPMI1GMUmQBqpwxYxTINe/CROoIfP4VMIkSZZ8jnx2KyGQmA=="],
+    "@takumi-rs/core": ["@takumi-rs/core@2.5.11", "", { "dependencies": { "@takumi-rs/helpers": "2.5.11" }, "optionalDependencies": { "@takumi-rs/core-darwin-arm64": "2.5.11", "@takumi-rs/core-darwin-x64": "2.5.11", "@takumi-rs/core-linux-arm64-gnu": "2.5.11", "@takumi-rs/core-linux-arm64-musl": "2.5.11", "@takumi-rs/core-linux-x64-gnu": "2.5.11", "@takumi-rs/core-linux-x64-musl": "2.5.11", "@takumi-rs/core-win32-arm64-msvc": "2.5.11", "@takumi-rs/core-win32-x64-msvc": "2.5.11" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-mBWcUXO7k2W4nDwNVZLu6I3qZaiFwyWxnxG5dlWzU76Sk2lwsADjaOW8RJy1W4+P0iBuyxnpLAJNTkmIGSqODQ=="],
 
-    "@takumi-rs/core-darwin-arm64": ["@takumi-rs/core-darwin-arm64@2.5.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1hq/mi+riaT77eToS/BJf0lBTX/jCUmnDqJgYyuq551D0JW0ArYJxnlehelFlReR8LeV3J/oqQgqXxrodeoDyg=="],
+    "@takumi-rs/core-darwin-arm64": ["@takumi-rs/core-darwin-arm64@2.5.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lyd7vgToq/BywgI1ANhnAFjFsAjzi/QacR/AkJN/b5Ir0piE1V78Uopgjqi2AMbGUQr52NSlNlLb2rDHi6qJ8Q=="],
 
-    "@takumi-rs/core-darwin-x64": ["@takumi-rs/core-darwin-x64@2.5.10", "", { "os": "darwin", "cpu": "x64" }, "sha512-JunN4oktWqiMlJ+Y+xDEyzG1xxr8f9ABb2+4G8xfK3/x6HHyrxon20bDmXd2Yjvh3xCiWm1TC5xFdcX0XX7NLg=="],
+    "@takumi-rs/core-darwin-x64": ["@takumi-rs/core-darwin-x64@2.5.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-bgAAUUwNmXPVrg67PrgqYyI8pIbtBqd5yH/vBb8jAdYNicwo0v/uzq1Hqy3qzO5OTMhahYoGmH5Mf7hx1oS6wA=="],
 
-    "@takumi-rs/core-linux-arm64-gnu": ["@takumi-rs/core-linux-arm64-gnu@2.5.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-2wRZToyZsSDZB3wLeUrbfDj7+eyUmasjcYdtXlxIIwNuQq39dbszazjKgNIG6E9JiUG7HWPUbZdzuc8tQpyDqA=="],
+    "@takumi-rs/core-linux-arm64-gnu": ["@takumi-rs/core-linux-arm64-gnu@2.5.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-stMnm9lkZRB7tdiD2+WIi1UfUkV8T9+2IpHQJaBqBMgG8gBN7ocIUnh/ddn21CEIPgjvOfKsogRGVB8zOzIDig=="],
 
-    "@takumi-rs/core-linux-arm64-musl": ["@takumi-rs/core-linux-arm64-musl@2.5.10", "", { "os": "linux", "cpu": "arm64" }, "sha512-YYxTO1NstjoH+CzNvLVotgwLKE/l/Y4XA+5FkQIw7iyN7m5a7E24qQEE6Xp8Ew62x2kdrJHcYsAEOU461Ttwdg=="],
+    "@takumi-rs/core-linux-arm64-musl": ["@takumi-rs/core-linux-arm64-musl@2.5.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-USGBroaIgRBgdQ9rQvU9O5q0RQ6aOE8H+Ti6LXFHnX7RUQjaSH2bMUtyWgeKkAHJxH3T4sUDZ3py4xSFiwbpFA=="],
 
-    "@takumi-rs/core-linux-x64-gnu": ["@takumi-rs/core-linux-x64-gnu@2.5.10", "", { "os": "linux", "cpu": "x64" }, "sha512-OTcYDjZ8MZTYEvpuVaPszNRiGG6H5kjeHr3qgCO/Ek4sldSDYlfKFjAABPeSSL+0sJvpExdQadeXVn0DKXCDhw=="],
+    "@takumi-rs/core-linux-x64-gnu": ["@takumi-rs/core-linux-x64-gnu@2.5.11", "", { "os": "linux", "cpu": "x64" }, "sha512-mfm1R/3PNqzWtBA22wkn7d724qumhNiTgbnv4uGiZgGDdJWFVT2bCxbu2/S2NxeB4jspreXeyTo5jxRMeR969Q=="],
 
-    "@takumi-rs/core-linux-x64-musl": ["@takumi-rs/core-linux-x64-musl@2.5.10", "", { "os": "linux", "cpu": "x64" }, "sha512-sowsR7EyxUO1uecFHVtD6V3I9fK1bvk15Gefmf8fnElQXCJF7Msi0/0g6PoIaRisWs1J8d+dOjEsVnS7KoxwIQ=="],
+    "@takumi-rs/core-linux-x64-musl": ["@takumi-rs/core-linux-x64-musl@2.5.11", "", { "os": "linux", "cpu": "x64" }, "sha512-9cQKh4awnp/YJFHh1i8fIEEbL5Yad5RDD3tSOTWBpOskL59iQI6QYn1iU3YKEnvH/LSsb+gRgFnjFg66RVYVIQ=="],
 
-    "@takumi-rs/core-win32-arm64-msvc": ["@takumi-rs/core-win32-arm64-msvc@2.5.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-cfl4MJkpU+4y48uQSUYvkxICr+9PWLY4Mei++OxYlREaVVjIhWDV4C1VeWvoVOLbdYdxK4L6/Ywjn/+9BU/h2w=="],
+    "@takumi-rs/core-win32-arm64-msvc": ["@takumi-rs/core-win32-arm64-msvc@2.5.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-67K6t4h35XpciRzi0dNoJPQUzPyTi0013hEg5Gvcw/JJJSVS83rHX9MQf+m6MF8eX0NFz1hhXN4okrAfdX0HSg=="],
 
-    "@takumi-rs/core-win32-x64-msvc": ["@takumi-rs/core-win32-x64-msvc@2.5.10", "", { "os": "win32", "cpu": "x64" }, "sha512-kg/pk74AG+ExV1jDEoJNrvHabBVhoj6a5r8tpSFlUUOz+njh8uspecoCq9GAzonPwURqEJSAgh1D+E8tHgNyqA=="],
+    "@takumi-rs/core-win32-x64-msvc": ["@takumi-rs/core-win32-x64-msvc@2.5.11", "", { "os": "win32", "cpu": "x64" }, "sha512-sNH++jpvw/s/47MlUlXcZUMv6U+5Wrgl36UM0rIaGPdl0gnO0dATbQih3fb5a4ImYH8E9fMCPMAyzlN73+YDFQ=="],
 
-    "@takumi-rs/helpers": ["@takumi-rs/helpers@2.5.10", "", { "peerDependencies": { "preact": "^10.0.0", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["preact", "react"] }, "sha512-bg+DUcJ5nKsB62Z4MH/sj6tyc32GlzEj8m9Q30A/WV8RYfvFygVVOfpYFMbJvmr+SxhPfTxDxLfIIktGCM8fQA=="],
+    "@takumi-rs/helpers": ["@takumi-rs/helpers@2.5.11", "", { "peerDependencies": { "preact": "^10.0.0", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["preact", "react"] }, "sha512-J6Fl3QMDfV/zKdiTUzJ16VJSUX778imyoVkU90uoqe0Fc9lK1/DVCmTpXq87jTjnkokAb9w2Y1hCT1XnyxqnAg=="],
 
-    "@takumi-rs/wasm": ["@takumi-rs/wasm@2.5.10", "", { "dependencies": { "@takumi-rs/helpers": "2.5.10" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-e8T4NGyfbqHyfwRVUYckSlT2vLZD4JEkcrCsaQGOxmcoVg4kqTu6CXDoJ+51OxdbG9jauWu2jLGm+/9EPzQLug=="],
+    "@takumi-rs/wasm": ["@takumi-rs/wasm@2.5.11", "", { "dependencies": { "@takumi-rs/helpers": "2.5.11" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-a1811+kj/6zLpTsza8dTLvhzMWf3hTYPO6rt2rHkxXLxUOKqeE1LUspsUNmYX0h1BQoCxQebxt7+MZP8B0zeZw=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -434,7 +434,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
@@ -446,7 +446,7 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.5", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA=="],
 
-    "@vitejs/plugin-rsc": ["@vitejs/plugin-rsc@0.5.32", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1", "es-module-lexer": "^2.3.1", "estree-walker": "^3.0.3", "magic-string": "^0.30.21", "srvx": "^0.12.4", "strip-literal": "^3.1.0", "turbo-stream": "^3.2.0", "vitefu": "^1.1.3" }, "peerDependencies": { "react": "*", "react-dom": "*", "react-server-dom-webpack": "*", "vite": "*" }, "optionalPeers": ["react-server-dom-webpack"] }, "sha512-9lKCNZ3gSV46CA6/r+0ONjUXfGuwIJeGcm60VapwWCEuCrhO0f9IBw3pLv+2usZtE2NztxQq5Rlum6b3XESRgw=="],
+    "@vitejs/plugin-rsc": ["@vitejs/plugin-rsc@0.5.34", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1", "es-module-lexer": "^2.3.1", "estree-walker": "^3.0.3", "magic-string": "^0.30.21", "srvx": "^0.12.4", "strip-literal": "^3.1.0", "turbo-stream": "^3.2.0", "vitefu": "^1.1.3" }, "peerDependencies": { "react": "*", "react-dom": "*", "react-server-dom-webpack": "*", "vite": "*" }, "optionalPeers": ["react-server-dom-webpack"] }, "sha512-95V6fyGQklQMYIWTr5qwwNmpDYxsHkTunuzq8i/keIcgdckL9zb6nyEgTnb1CEl1IPJWVxGgORMkTFHrct7XJg=="],
 
     "@webassemblyjs/ast": ["@webassemblyjs/ast@1.14.1", "", { "dependencies": { "@webassemblyjs/helper-numbers": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2" } }, "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ=="],
 
@@ -662,11 +662,11 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "fumadocs-core": ["fumadocs-core@16.14.1", "", { "dependencies": { "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "hast-util-to-estree": "^3.1.3", "hast-util-to-jsx-runtime": "^2.3.6", "mdast-util-mdx": "^3.0.0", "mdast-util-to-markdown": "^2.1.2", "npm-to-yarn": "3.2.0", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "remark-rehype": "^11.1.2", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.4.1", "tinyglobby": "^0.2.17", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3", "yaml": "^2.9.0", "zbsearch": "^3.3.4" }, "peerDependencies": { "@mdx-js/mdx": "*", "@mixedbread/sdk": "0.x.x", "@orama/core": "1.x.x", "@oramacloud/client": "2.x.x", "@tanstack/react-router": "1.x.x", "@types/estree-jsx": "*", "@types/hast": "*", "@types/mdast": "*", "@types/react": "*", "algoliasearch": "5.x.x", "flexsearch": "*", "lucide-react": "*", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "react-router": "7.x.x || 8.x.x", "waku": "*", "zod": "4.x.x" }, "optionalPeers": ["@mdx-js/mdx", "@mixedbread/sdk", "@orama/core", "@oramacloud/client", "@tanstack/react-router", "@types/estree-jsx", "@types/hast", "@types/mdast", "@types/react", "algoliasearch", "flexsearch", "lucide-react", "next", "react", "react-dom", "react-router", "waku", "zod"] }, "sha512-Bhyd0J8gMWtX9o1eFvR/9/Cc0/5Al/jMIf4ukeNtHhjRCkT0fXsPFXiFgKPtWMBdKpffx9WRbVewtcc0py0rnw=="],
+    "fumadocs-core": ["fumadocs-core@16.14.2", "", { "dependencies": { "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "hast-util-to-estree": "^3.1.3", "hast-util-to-jsx-runtime": "^2.3.6", "mdast-util-mdx": "^3.0.0", "mdast-util-to-markdown": "^2.1.2", "npm-to-yarn": "3.2.0", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "remark-rehype": "^11.1.2", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.4.1", "tinyglobby": "^0.2.17", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3", "yaml": "^2.9.0", "zbsearch": "^3.3.4" }, "peerDependencies": { "@mdx-js/mdx": "*", "@mixedbread/sdk": "0.x.x", "@orama/core": "1.x.x", "@oramacloud/client": "2.x.x", "@tanstack/react-router": "1.x.x", "@types/estree-jsx": "*", "@types/hast": "*", "@types/mdast": "*", "@types/react": "*", "algoliasearch": "5.x.x", "flexsearch": "*", "lucide-react": "*", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "react-router": "7.x.x || 8.x.x", "waku": "*", "zod": "4.x.x" }, "optionalPeers": ["@mdx-js/mdx", "@mixedbread/sdk", "@orama/core", "@oramacloud/client", "@tanstack/react-router", "@types/estree-jsx", "@types/hast", "@types/mdast", "@types/react", "algoliasearch", "flexsearch", "lucide-react", "next", "react", "react-dom", "react-router", "waku", "zod"] }, "sha512-Wk4111Q0YdRN+ZEzm4cQaJaUCd3a70exPi70ibhIK/QpCiMwyAhypQ1us+LEDQphRW6IhcL0mBlIuNsxk1YFcA=="],
 
     "fumadocs-mdx": ["fumadocs-mdx@15.2.2", "", { "dependencies": { "@mdx-js/mdx": "^3.1.1", "@standard-schema/spec": "^1.1.0", "chokidar": "^5.0.0", "esbuild": "^0.28.1", "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "magic-string": "^1.1.0", "mdast-util-mdx": "^3.0.0", "picocolors": "^1.1.1", "picomatch": "^4.0.5", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3", "yaml": "^2.9.0", "yuku-analyzer": "^0.8.1", "zod": "^4.4.3" }, "peerDependencies": { "@fumadocs/satteri": "0.x.x", "@types/mdast": "*", "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "^16.7.0", "mdast-util-directive": "*", "next": "^15.3.0 || ^16.0.0", "react": "^19.2.0", "rolldown": "*", "satteri": "^0.9.4", "vite": "7.x.x || 8.x.x" }, "optionalPeers": ["@fumadocs/satteri", "@types/mdast", "@types/mdx", "@types/react", "mdast-util-directive", "next", "react", "rolldown", "satteri", "vite"], "bin": { "fumadocs-mdx": "./bin.js" } }, "sha512-cWtGFSDSWOTykuxym3uzfuIkK9oWyNcAeIWgjqfS1QbkrY9nAh9fmoPCFwMcw7alk5oX5l8sxvRsUG+ZTuShNQ=="],
 
-    "fumadocs-ui": ["@fumadocs/base-ui@16.14.1", "", { "dependencies": { "@base-ui/react": "^1.7.0", "@fuma-translate/react": "^1.0.2", "@fumadocs/tailwind": "0.1.1", "class-variance-authority": "^0.7.1", "cnfast": "^0.1.0", "lucide-react": "^1.28.0", "motion": "^12.43.0", "next-themes": "^0.4.6", "react-remove-scroll": "^2.7.2", "rehype-raw": "^7.0.0", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.4.1", "unist-util-visit": "^5.1.0" }, "peerDependencies": { "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "16.14.1", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "takumi-js": "*" }, "optionalPeers": ["@types/mdx", "@types/react", "next", "takumi-js"] }, "sha512-S1CAMPX1LxHxciBO08jcj2h8h5ShU3z61s+47GQY1ODJVBI62rzhzw+2q+1ruEzmUv7NPqvY6/D8cwWe/A8+Ww=="],
+    "fumadocs-ui": ["@fumadocs/base-ui@16.14.2", "", { "dependencies": { "@base-ui/react": "^1.7.0", "@fuma-translate/react": "^1.0.2", "@fumadocs/tailwind": "0.1.1", "class-variance-authority": "^0.7.1", "cnfast": "^0.1.0", "lucide-react": "^1.28.0", "motion": "^12.43.0", "next-themes": "^0.4.6", "react-remove-scroll": "^2.7.2", "rehype-raw": "^7.0.0", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.4.1", "unist-util-visit": "^5.1.0" }, "peerDependencies": { "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "16.14.2", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "takumi-js": "*" }, "optionalPeers": ["@types/mdx", "@types/react", "next", "takumi-js"] }, "sha512-aDyiJjPNO2zvXTnoFPCN4YOPx98lEHEbeG5KUgRPhMZQCTN7Mrz28HLDZOzqgiZWdTDMv2MWhOTeFsRi4howZw=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
@@ -754,7 +754,7 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
-    "lucide-react": ["lucide-react@1.29.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg=="],
+    "lucide-react": ["lucide-react@1.30.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tUIr2jXLbWpCkdtH8XP7P7YppM9ueWgTky99lpWDY6z5REs6B+O6ZQ3U5tHkUUY59ANyOv/PBcs8E4Fe3KO3eA=="],
 
     "magic-string": ["magic-string@1.1.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g=="],
 
@@ -1012,7 +1012,7 @@
 
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
-    "takumi-js": ["takumi-js@2.5.10", "", { "dependencies": { "@takumi-rs/core": "2.5.10", "@takumi-rs/helpers": "2.5.10", "@takumi-rs/wasm": "2.5.10" } }, "sha512-P5DDKW5u06kumyedEyHijgMm2seyvkunqnm7ATTEW7GgsRkIAt3mPz2qVR3KGrq8vhL5Yjcxjt4pH9RrlzV0cw=="],
+    "takumi-js": ["takumi-js@2.5.11", "", { "dependencies": { "@takumi-rs/core": "2.5.11", "@takumi-rs/helpers": "2.5.11", "@takumi-rs/wasm": "2.5.11" } }, "sha512-E8pr3vPXt3ZgUerXGD2VtXBxze9CDNvqLJ4Y9TRXRuIf3Uu0jglunn64inRjfKBa08NPZQsawAwgvdLX9BUy1A=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -1032,7 +1032,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsx": ["tsx@4.23.9", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-6q8uTORRGauQVjqMQnKUucLFoeXZAfw6zKvG35GLbdKWbLdeOtZ3H4mhyA5mxuUd2o2cRTskhj59nLLQseUvUw=="],
+    "tsx": ["tsx@4.23.11", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw=="],
 
     "turbo-stream": ["turbo-stream@3.2.0", "", {}, "sha512-EK+bZ9UVrVh7JLslVFOV0GEMsociOqVOvEMTAd4ixMyffN5YNIEdLZWXUx5PJqDbTxSIBWw04HS9gCY4frYQDQ=="],
 
@@ -1082,7 +1082,7 @@
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
-    "waku": ["waku@1.0.0-beta.8", "", { "dependencies": { "@hono/node-server": "^2.0.10", "@vitejs/plugin-react": "^6.0.1", "@vitejs/plugin-rsc": "^0.5.30", "dotenv": "^17.4.2", "hono": "^4.12.14", "magic-string": "^1.0.0", "picocolors": "^1.1.1", "rsc-html-stream": "^0.0.7", "vite": "^8.0.0" }, "peerDependencies": { "react": "~19.2.4", "react-dom": "~19.2.4", "react-server-dom-webpack": "~19.2.4" }, "bin": { "waku": "./cli.js" } }, "sha512-+Ek51aw/L0KwjCqlS8ZYB37t3H1BKbJIMd2rP7BsL0C/3FQvS9lH13SheowZqEe1rop01jkQr4bZzXAjt6cn5w=="],
+    "waku": ["waku@1.0.0-beta.9", "", { "dependencies": { "@hono/node-server": "^2.0.11", "@vitejs/plugin-react": "^6.0.1", "@vitejs/plugin-rsc": "^0.5.33", "dotenv": "^17.4.2", "hono": "^4.12.14", "magic-string": "^1.0.0", "picocolors": "^1.1.1", "rsc-html-stream": "^0.0.7", "vite": "^8.0.0" }, "peerDependencies": { "react": "~19.2.4", "react-dom": "~19.2.4", "react-server-dom-webpack": "~19.2.4" }, "bin": { "waku": "./cli.js" } }, "sha512-XSFP07L2u5XoZf2Qt3k6AGv9q4Iogzdt9be6imJjpld/VUVZhTA5KzL3aBEdjuplYJNlNZLMZPdM9j1Kw62ZUA=="],
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
@@ -1143,8 +1143,6 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
-
-    "waku/vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
 
     "@rolldown/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@2.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ=="],
 

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -34,7 +34,7 @@ Never leave the reader guessing what comes back from a call.
 2. Use `'games.pgn'` in code samples — not `'<pathToPgnFile>'` or abstract placeholders.
 3. For every public function you introduce, show **real return shapes**: `AnalyzeResult`, `ParsedGame[]`, tracker `.state`, `HeatmapData`, error entries, etc.
 4. Prefer **annotated excerpts** when full JSON is huge (e.g. trim `byPiece` zeros, keep the squares that tell the story). Say when something is trimmed.
-5. When an output is machine-sensitive (`durationMs`, `movesPerSecond`), note that the reader's numbers will differ.
+5. When an output is machine-sensitive (`perf.durationMs`, `perf.movesPerSecond`), note that the reader's numbers will differ.
 
 ### Regenerating outputs
 

--- a/docs/content/docs/comparing-analyses.mdx
+++ b/docs/content/docs/comparing-analyses.mdx
@@ -5,7 +5,7 @@ description: Analyze two filtered groups in one pass and diff their heatmaps.
 
 Some questions are really comparisons in disguise: do high-rated players use the center differently than beginners? The `runs` option lets you analyze several groups — each with its own trackers and filter — in a single call:
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import { generateComparisonHeatmap, tileAt, tileTracker } from 'chessalyzer/trackers';
 
@@ -33,7 +33,7 @@ Each run accumulates into its own tracker instances: on our [example file](/docs
 
 `generateComparisonHeatmap(stateA, stateB, fn)` runs the same per-square function over both states and returns the **percentage difference** per square: positive means group A scored higher, negative means group B did, and `0` whenever either side has nothing to compare. The result is a regular [`HeatmapData`](/docs/heatmaps) (`{ map, min, max }`), so `printHeatmap` works on it — blue cells favor group B, orange cells favor group A:
 
-```javascript
+```typescript
 const diff = generateComparisonHeatmap(high.state, low.state, ({ data, square }) => {
     const cell = tileAt(data.tiles, square);
     if (!cell) return 0;

--- a/docs/content/docs/error-handling.mdx
+++ b/docs/content/docs/error-handling.mdx
@@ -20,7 +20,7 @@ To try both, imagine our [example file](/docs/quickstart#the-example-file) with 
 
 By default, `analyzePGN` throws as soon as a game can't be replayed. That's what you want while developing — you notice bad data immediately:
 
-```javascript
+```typescript
 import { analyzePGN, isReplayError } from 'chessalyzer';
 
 try {
@@ -40,7 +40,7 @@ try {
 
 For batch runs over mostly-good data (think Lichess database dumps), aborting on one bad apple wastes the whole run. `onError: 'skip-game'` collects the failures and finishes the rest:
 
-```javascript
+```typescript
 const result = await analyzePGN('games.pgn', {
     trackers: [tiles],
     onError: 'skip-game',

--- a/docs/content/docs/error-handling.mdx
+++ b/docs/content/docs/error-handling.mdx
@@ -68,7 +68,7 @@ The three good games are fully processed, and the result tells you exactly what 
 }
 ```
 
-(`durationMs` and `movesPerSecond` omitted — they're there too. Each entry in `runs` mirrors its own `skippedGames`/`errors` when you use [multiple runs](/docs/comparing-analyses), omitted when zero.)
+(`perf.durationMs` and `perf.movesPerSecond` omitted — they're there too inside `result.perf`. Each entry in `runs` mirrors its own `skippedGames`/`errors` when you use [multiple runs](/docs/comparing-analyses), omitted when zero.)
 
 Two limits to know: `errors` holds at most **100 entries** — past that, `result.errorsTruncated` is `true` and counting continues silently — and Chessalyzer never prints anything by itself, so what happens with these errors is entirely your call.
 

--- a/docs/content/docs/filters.mdx
+++ b/docs/content/docs/filters.mdx
@@ -7,7 +7,7 @@ Often you don't want _every_ game — only the ones worth your question. Pass a 
 
 Only one game in our [example file](/docs/quickstart#the-example-file) has a white player rated above 2000 (alice, 2114), so this analysis processes exactly one game:
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import { tileTracker } from 'chessalyzer/trackers';
 
@@ -36,7 +36,7 @@ The filter receives the same [`ParsedGame`](/docs/parsing-pgn) shape you know fr
 
 Combine with `maxGames` to cap how many _matching_ games are processed — a quick way to sample:
 
-```javascript
+```typescript
 await analyzePGN('huge-database.pgn', {
     trackers: [tiles],
     filter: (game) => game.headers?.Result === '1/2-1/2',

--- a/docs/content/docs/heatmaps/custom-functions.mdx
+++ b/docs/content/docs/heatmaps/custom-functions.mdx
@@ -7,7 +7,7 @@ A heatmap function answers one small question — "what value should this square
 
 Here's one from scratch: "how much of the game did white pieces occupy each square?" (as a percentage of all half-moves):
 
-```javascript
+```typescript
 import { generateHeatmap, tileAt } from 'chessalyzer/trackers';
 
 const heatmapData = generateHeatmap(tiles.state, ({ data, square }) => {
@@ -19,7 +19,7 @@ const heatmapData = generateHeatmap(tiles.state, ({ data, square }) => {
 
 Need an extra value in your function — a piece you care about, a precomputed average? Just close over it:
 
-```javascript
+```typescript
 const queen = { color: 'w', name: 'Qd' };
 
 const queenSquares = generateHeatmap(tiles.state, ({ data, square }) => {

--- a/docs/content/docs/heatmaps/index.mdx
+++ b/docs/content/docs/heatmaps/index.mdx
@@ -5,7 +5,7 @@ description: Turn tracker state into per-square values for preview or visualizat
 
 Tracker state is precise but hard to eyeball — 64 squares times a handful of counters. A **heatmap** boils it down to one number per square, so patterns jump out. Chessalyzer gives you the numbers and a quick terminal preview; what you build on top (web boards, charts, posters) is up to you.
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import {
     generateHeatmap,

--- a/docs/content/docs/heatmaps/presets.mdx
+++ b/docs/content/docs/heatmaps/presets.mdx
@@ -5,7 +5,7 @@ description: Built-in heatmap functions for common tile and piece questions.
 
 Presets are ready-made heatmap functions — pass one to `generateHeatmap` and you're done. They come in two flavors: **plain presets** are used as-is, and **scoped presets** are little factories you call with a piece or square first.
 
-```javascript
+```typescript
 import { generateHeatmap, TileHeatmapPresets } from 'chessalyzer/trackers';
 
 // plain preset — use directly

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -6,7 +6,7 @@ icon: BookOpen
 
 Chessalyzer is a JavaScript library that reads chess games from PGN files and collects exactly the statistics you care about — for a handful of games or for millions of them.
 
-You tell it **what to measure** by attaching small building blocks called **Trackers** (count results, watch what happens on each square, or invent your own statistic). Chessalyzer takes care of the boring parts: reading the file, understanding the moves, and adding everything up. When it's done, you simply read the results off your trackers.
+You tell it **what to measure** by attaching small building blocks called **[Trackers](/docs/trackers)** (count results, watch what happens on each square, or invent your own statistic). Chessalyzer takes care of the boring parts: reading the file, understanding the moves, and adding everything up. When it's done, you simply read the results off your trackers.
 
 ```javascript
 import { analyzePGN } from 'chessalyzer';

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -6,7 +6,7 @@ icon: BookOpen
 
 Chessalyzer is a JavaScript library that reads chess games from PGN files and collects exactly the statistics you care about — for a handful of games or for millions of them.
 
-You tell it **what to measure** by attaching small building blocks called **trackers** (count results, watch what happens on each square, or invent your own statistic). Chessalyzer takes care of the boring parts: reading the file, understanding the moves, and adding everything up. When it's done, you simply read the results off your trackers.
+You tell it **what to measure** by attaching small building blocks called **Trackers** (count results, watch what happens on each square, or invent your own statistic). Chessalyzer takes care of the boring parts: reading the file, understanding the moves, and adding everything up. When it's done, you simply read the results off your trackers.
 
 ```javascript
 import { analyzePGN } from 'chessalyzer';

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -8,7 +8,7 @@ Chessalyzer is a JavaScript library that reads chess games from PGN files and co
 
 You tell it **what to measure** by attaching small building blocks called **[Trackers](/docs/trackers)** (count results, watch what happens on each square, or invent your own statistic). Chessalyzer takes care of the boring parts: reading the file, understanding the moves, and adding everything up. When it's done, you simply read the results off your trackers.
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import { gameTracker } from 'chessalyzer/trackers';
 

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -29,9 +29,9 @@ import { parsePGN, streamParsePGN } from 'chessalyzer/pgn';
 
 Don't worry about memorizing these — the guides always show the right import at the top of each example.
 
-## See it work
+## Basic usage
 
-If you have a PGN file lying around, this is a complete program:
+If you have a PGN file lying around, this is a complete parse + analyze run:
 
 ```javascript
 import { analyzePGN } from 'chessalyzer';

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -5,15 +5,15 @@ description: Install Chessalyzer and import the modules you need.
 
 Chessalyzer runs on any **JavaScript runtime**, with **Node.js ≥ 22** or **Bun** being recommended. There are no other requirements, and the library itself has zero dependencies.
 
-```sh
-npm install chessalyzer
+```package-install
+chessalyzer
 ```
 
 ## What you can import
 
 The main entry point is `chessalyzer`, with a few extra subpaths for the parts you only need sometimes:
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import { tileTracker, printHeatmap } from 'chessalyzer/trackers';
 import { parsePGN, streamParsePGN } from 'chessalyzer/pgn';
@@ -33,7 +33,7 @@ Don't worry about memorizing these — the guides always show the right import a
 
 If you have a PGN file lying around, this is a complete parse + analyze run:
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import { tileTracker } from 'chessalyzer/trackers';
 

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -3,7 +3,7 @@ title: Installation
 description: Install Chessalyzer and import the modules you need.
 ---
 
-Chessalyzer runs on **Node.js ≥ 22** or **Bun** — pick whichever you already have. There are no other requirements, and the library itself has zero dependencies.
+Chessalyzer runs on any **JavaScript runtime**, with **Node.js ≥ 22** or **Bun** being recommended. There are no other requirements, and the library itself has zero dependencies.
 
 ```sh
 npm install chessalyzer

--- a/docs/content/docs/multithreading.mdx
+++ b/docs/content/docs/multithreading.mdx
@@ -32,7 +32,7 @@ main thread:  merge tracker states ◄── snapshots ◄───────�
 
 Defaults are sensible for most files (one worker per available core). When you do tune, `workers` takes an object (or a plain number for the thread count):
 
-```javascript
+```typescript
 await analyzePGN('games.pgn', {
     trackers: [tiles],
     workers: { count: 8, chunk: { targetBytes: 4 * 1024 * 1024 } },
@@ -52,7 +52,7 @@ Bigger chunks mean less dispatch overhead; smaller chunks balance better when ga
 
 Pass `workers: false` to force everything onto the main thread:
 
-```javascript
+```typescript
 await analyzePGN('games.pgn', { trackers: [tiles], workers: false });
 ```
 

--- a/docs/content/docs/parsing-pgn.mdx
+++ b/docs/content/docs/parsing-pgn.mdx
@@ -9,7 +9,7 @@ Both examples below run on the [three-game `games.pgn`](/docs/quickstart#the-exa
 
 ## parsePGN — all games at once
 
-```javascript
+```typescript
 import { parsePGN } from 'chessalyzer/pgn';
 
 const games = await parsePGN('games.pgn', { headers: true });
@@ -64,7 +64,7 @@ A few things worth knowing about this shape:
 
 Same data, delivered as an async iterator. The whole file never sits in memory at once:
 
-```javascript
+```typescript
 import { streamParsePGN } from 'chessalyzer/pgn';
 
 for await (const game of streamParsePGN('games.pgn', { headers: true })) {

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -70,10 +70,12 @@ Two things to notice: you **create a tracker instance** (`tileTracker()`) and ha
 
 ```json
 {
-    "durationMs": 33.99,
     "gameCount": 3,
     "moveCount": 19,
-    "movesPerSecond": 559,
+    "perf": {
+        "durationMs": 33.99,
+        "movesPerSecond": 559
+    },
     "runs": [
         {
             "gameCount": 3,
@@ -84,10 +86,10 @@ Two things to notice: you **create a tracker instance** (`tileTracker()`) and ha
 ```
 
 <Callout type="info" title="Your numbers will differ">
-    `durationMs` and `movesPerSecond` depend on your machine, and 3 games finish in the blink of an
-    eye — throughput gets interesting on files with thousands or millions of games. The `runs` array
-    has one entry per analysis pass; there's exactly one here, and [Comparing
-    groups](/docs/comparing-analyses) shows when you'd want more.
+    The `perf` entries (`durationMs` and `movesPerSecond`) depend on your machine, and 3 games
+    finish in the blink of an eye — throughput gets interesting on files with thousands or millions
+    of games. The `runs` array has one entry per analysis pass; there's exactly one here, and
+    [Comparing groups](/docs/comparing-analyses) shows when you'd want more.
 </Callout>
 
 The actual statistics live on your tracker. `tiles.state` counts 19 half-moves, and each square has its own little report — here's `e4`, the square white's king pawn moved to in two of our three games:

--- a/docs/content/docs/quickstart.mdx
+++ b/docs/content/docs/quickstart.mdx
@@ -51,7 +51,7 @@ Save these three games as `games.pgn`. They are deliberately short (a quick win,
 
 We'll ask the built-in `tileTracker` to watch every square of the board — who moved where, who got captured where, and how long each piece stayed put:
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import { tileTracker } from 'chessalyzer/trackers';
 
@@ -92,7 +92,7 @@ Two things to notice: you **create a tracker instance** (`tileTracker()`) and ha
 
 The actual statistics live on your tracker. `tiles.state` counts 19 half-moves, and each square has its own little report — here's `e4`, the square white's king pawn moved to in two of our three games:
 
-```javascript
+```typescript
 console.log(tiles.state.movesTotal); // 19
 console.log(tiles.state.tiles); // 8×8 grid of square reports
 ```
@@ -120,7 +120,7 @@ White's e-pawn (`Pe`) moved to e4 twice and then sat there for 13 half-moves in 
 
 Numbers per square are nice; a heatmap makes patterns pop. `generateHeatmap` maps the state to one value per square, and `printHeatmap` renders a colored board in your terminal:
 
-```javascript
+```typescript
 import { generateHeatmap, printHeatmap, TileHeatmapPresets } from 'chessalyzer/trackers';
 
 const heatmapData = generateHeatmap(tiles.state, TileHeatmapPresets.TILE_OCC_ALL);

--- a/docs/content/docs/trackers/built-in.mdx
+++ b/docs/content/docs/trackers/built-in.mdx
@@ -9,7 +9,7 @@ Chessalyzer ships with three ready-made trackers. All examples below run on the 
 
 The simplest of the three: it reads each game's headers and result, and counts. It needs headers, which Chessalyzer parses automatically as soon as a game tracker is attached.
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import { gameTracker } from 'chessalyzer/trackers';
 
@@ -37,7 +37,7 @@ console.log(games.state);
 
 A capture matrix: for every starting piece, how often it captured each opposing piece. Pieces are named by their starting square — `Qd` is the queen, `Pe` the king's pawn, `Nb` the knight that began on the b-file — and each color gets its own table under `w` and `b`.
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import { pieceTracker } from 'chessalyzer/trackers';
 
@@ -70,7 +70,7 @@ The workhorse. For each of the 64 squares it records, per color and per piece:
 - `captures` — captures that happened _on_ this square
 - `losses` — pieces that were captured _on_ this square
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import { tileAt, tileTracker } from 'chessalyzer/trackers';
 

--- a/docs/content/docs/trackers/custom.mdx
+++ b/docs/content/docs/trackers/custom.mdx
@@ -34,7 +34,7 @@ export default defineMoveTracker({
 
 Then use it like any built-in:
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import halfMoveCounter from './half-move-counter.ts';
 
@@ -89,7 +89,7 @@ Use `onGameEnd(state)` for per-game flush logic and `onFinish(state)` for final 
 
 ## Types you'll want
 
-```javascript
+```typescript
 import type { ParsedGame, ParsedMove } from 'chessalyzer/pgn';
 import type { Action } from 'chessalyzer/replay';
 import type { PieceName, Square } from 'chessalyzer/board';

--- a/docs/content/docs/trackers/index.mdx
+++ b/docs/content/docs/trackers/index.mdx
@@ -13,7 +13,7 @@ You'll meet three words over and over:
 - An **instance** is what the factory hands back — the handle you pass to `analyzePGN`.
 - The **state** is where the instance accumulates its numbers. After the analysis finishes, you read `instance.state`.
 
-```javascript
+```typescript
 import { analyzePGN } from 'chessalyzer';
 import { tileTracker, gameTracker } from 'chessalyzer/trackers';
 

--- a/docs/examples/generate-outputs.ts
+++ b/docs/examples/generate-outputs.ts
@@ -33,18 +33,16 @@ function print(label: string, value: unknown): void {
     console.log(value);
 }
 
-function json(value: unknown): string {
-    return JSON.stringify(value, null, 2);
+function json(value: unknown, keys?: string[]): string {
+    return JSON.stringify(value, keys, 2);
 }
 
 // --- analyzePGN: result object (quickstart, installation) ---
-
 const tiles = tileTracker();
 const analyzeResult = await analyzePGN(PGN, { trackers: [tiles] });
 print('ANALYZE_RESULT', json(analyzeResult));
 
 // --- tileTracker state excerpts (quickstart, built-in trackers) ---
-
 const TILE_SQUARES = ['e4', 'e5', 'f7', 'd7', 'h4'] as const;
 const tileExcerpt: Record<string, unknown> = { movesTotal: tiles.state.movesTotal };
 for (const square of TILE_SQUARES) {
@@ -53,19 +51,16 @@ for (const square of TILE_SQUARES) {
 print('TILE_STATE_EXCERPT', json(tileExcerpt));
 
 // --- gameTracker state (built-in trackers) ---
-
 const games = gameTracker();
 await analyzePGN(PGN, { trackers: [games] });
 print('GAME_STATE', json(games.state));
 
 // --- pieceTracker state (built-in trackers) ---
-
 const pieces = pieceTracker();
 await analyzePGN(PGN, { trackers: [pieces] });
 print('PIECE_STATE', json(pieces.state));
 
 // --- parsePGN / streamParsePGN (parsing PGN files) ---
-
 const parsed = await parsePGN(PGN, { headers: true });
 print('PARSED_GAMES', json(parsed));
 
@@ -78,7 +73,6 @@ for await (const game of streamParsePGN(PGN, { headers: true })) {
 }
 
 // --- heatmaps (heatmaps, quickstart) ---
-
 const heat = generateHeatmap(tiles.state, TileHeatmapPresets.TILE_OCC_ALL);
 print('HEATMAP_MIN_MAX', json({ min: heat.min, max: heat.max }));
 
@@ -93,7 +87,6 @@ print(
 );
 
 // --- filter (filters) ---
-
 const filtered = tileTracker();
 const filterResult = await analyzePGN(PGN, {
     trackers: [filtered],
@@ -102,7 +95,6 @@ const filterResult = await analyzePGN(PGN, {
 print('FILTER_RESULT', json(filterResult));
 
 // --- comparing analyses (runs + comparison heatmap) ---
-
 const high = tileTracker();
 const low = tileTracker();
 await analyzePGN(PGN, {
@@ -131,7 +123,6 @@ print(
 );
 
 // --- custom move tracker numbers (custom trackers walkthrough) ---
-
 const counter = defineMoveTracker({
     id: 'half-move-counter',
     init: () => ({ halfMoves: 0, captures: 0 }),
@@ -152,7 +143,6 @@ await analyzePGN(PGN, { trackers: [counter], workers: false });
 print('HALF_MOVE_COUNTER_STATE', json(counter.state));
 
 // --- error handling (skip-game on a file with a broken 4th game) ---
-
 const badGame = `
 [Event "Broken game"]
 [White "blunderbuss"]
@@ -174,7 +164,7 @@ try {
         // default worker pool — typed ReplayError must survive the thread boundary
         await analyzePGN(TMP_BAD_PGN, { trackers: [tileTracker()] });
     } catch (err) {
-        print('ABORT_THROWN', json(err, Object.getOwnPropertyNames(err as object)));
+        print('ABORT_THROWN', json(err, Object.getOwnPropertyNames(err)));
         print('ABORT_IS_REPLAY_ERROR', String(isReplayError(err)));
     }
 } finally {

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,21 +12,21 @@
         "lint": "oxlint"
     },
     "dependencies": {
-        "fumadocs-core": "16.14.1",
+        "fumadocs-core": "16.14.2",
         "fumadocs-mdx": "15.2.2",
-        "fumadocs-ui": "npm:@fumadocs/base-ui@16.14.1",
-        "lucide-react": "^1.29.0",
+        "fumadocs-ui": "npm:@fumadocs/base-ui@16.14.2",
+        "lucide-react": "^1.30.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-server-dom-webpack": "^19.2.8",
-        "takumi-js": "^2.5.10",
+        "takumi-js": "^2.5.11",
         "use-sync-external-store": "^1.6.0",
-        "waku": "1.0.0-beta.8"
+        "waku": "1.0.0-beta.9"
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.3.3",
         "@types/mdx": "^2.0.14",
-        "@types/node": "^26.1.2",
+        "@types/node": "^26.2.0",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "tailwindcss": "^4.3.3",

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -10,3 +10,8 @@ body {
     margin-right: 0px !important;
     --removed-body-scroll-bar-size: 0px !important;
 }
+
+/* Show empty lines in code blocks (plain text type) */
+code > .line > span:empty {
+    display: inline-block;
+}

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     },
     "devDependencies": {
         "@types/bun": "^1.3.14",
-        "@types/node": "^26.1.2",
+        "@types/node": "^26.2.0",
         "bumpp": "^12.2.0",
         "bun-plugin-dts": "^0.4.0",
         "knip": "^6.32.0",
@@ -91,11 +91,11 @@
         "oxlint": "^1.77.0",
         "oxlint-tsgolint": "^7.0.2001",
         "tinybench": "^6.1.2",
-        "tsx": "^4.23.9",
+        "tsx": "^4.23.11",
         "typescript": "6.0.3"
     },
     "overrides": {
-        "@types/node": "^26.1.2"
+        "@types/node": "^26.2.0"
     },
     "engines": {
         "node": ">=22"

--- a/src/core/__tests__/analyze.test.ts
+++ b/src/core/__tests__/analyze.test.ts
@@ -20,7 +20,7 @@ describe('analyzePGN result shape', () => {
 
         expect(result.runs).toHaveLength(1);
         expect(result.runs[0]?.gameCount).toBe(result.gameCount);
-        expect(result.movesPerSecond).toBeGreaterThan(0);
+        expect(result.perf.movesPerSecond).toBeGreaterThan(0);
         expect(tiles.state.movesTotal).toBe(result.moveCount);
     });
 

--- a/src/core/analyze.ts
+++ b/src/core/analyze.ts
@@ -41,10 +41,12 @@ function buildResultBase(
     }
 
     const result: Omit<AnalyzeResult, 'runs'> = {
-        durationMs,
         gameCount,
         moveCount,
-        movesPerSecond: durationMs > 0 ? Math.round(moveCount / (durationMs / 1000)) : 0,
+        perf: {
+            durationMs,
+            movesPerSecond: durationMs > 0 ? Math.round(moveCount / (durationMs / 1000)) : 0,
+        },
     };
 
     if (skippedGames > 0) {

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -113,10 +113,16 @@ export interface AnalyzeRunResult {
     errors?: AnalyzeError[];
 }
 
-/** Result from `analyzePGN`. Always contains one {@link AnalyzeRunResult} per run. */
-export interface AnalyzeResult {
+/** Performance and throughput telemetry returned by {@link analyzePGN}. */
+interface AnalyzePerformance {
     /** Wall time for the whole call in milliseconds. */
     durationMs: number;
+    /** Call-level move throughput from total moves and {@link durationMs}. */
+    movesPerSecond: number;
+}
+
+/** Result from `analyzePGN`. Always contains one {@link AnalyzeRunResult} per run. */
+export interface AnalyzeResult {
     /**
      * Sum of {@link AnalyzeRunResult.gameCount} across runs.
      * With a single run, equals that run's processed game count. With multiple `runs`, sums each pass over the file.
@@ -124,8 +130,8 @@ export interface AnalyzeResult {
     gameCount: number;
     /** Sum of {@link AnalyzeRunResult.moveCount} across runs. */
     moveCount: number;
-    /** Call-level throughput from total moves and {@link durationMs}. */
-    movesPerSecond: number;
+    /** Performance and throughput metrics for the call. */
+    perf: AnalyzePerformance;
     /** Games skipped due to replay failure when `onError: 'skip-game'`. */
     skippedGames?: number;
     /** Collected replay errors when `onError: 'skip-game'` (capped at 100). */


### PR DESCRIPTION
- Moves `durationMs` and `movesPerSecond` on the analyzePGN return type into a dedicated perf object for separation of concerns
- Use typescript instead of javascript for all md code blocks
- Manual review of first pages of docs -> small tweaks